### PR TITLE
Delay secondary database call

### DIFF
--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/MirroringResultScanner.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/MirroringResultScanner.java
@@ -177,11 +177,11 @@ public class MirroringResultScanner extends AbstractClientScanner implements Lis
 
   private <T> void scheduleRequest(
       RequestResourcesDescription requestResourcesDescription,
-      Supplier<ListenableFuture<T>> next,
+      Supplier<ListenableFuture<T>> nextSupplier,
       FutureCallback<T> scannerNext) {
     this.listenableReferenceCounter.holdReferenceUntilCompletion(
         RequestScheduling.scheduleVerificationAndRequestWithFlowControl(
-            requestResourcesDescription, next, scannerNext, this.flowController));
+            requestResourcesDescription, nextSupplier, scannerNext, this.flowController));
   }
 
   @Override

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/MirroringTable.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/MirroringTable.java
@@ -547,21 +547,21 @@ public class MirroringTable implements Table, ListenableCloseable {
 
   private <T> void scheduleVerificationAndRequestWithFlowControl(
       final RequestResourcesDescription resultInfo,
-      final Supplier<ListenableFuture<T>> secondaryGetFutureCaller,
+      final Supplier<ListenableFuture<T>> secondaryGetFutureSupplier,
       final FutureCallback<T> verificationCallback) {
     this.referenceCounter.holdReferenceUntilCompletion(
         RequestScheduling.scheduleVerificationAndRequestWithFlowControl(
-            resultInfo, secondaryGetFutureCaller, verificationCallback, this.flowController));
+            resultInfo, secondaryGetFutureSupplier, verificationCallback, this.flowController));
   }
 
   public <T> void scheduleWriteWithControlFlow(
       final WriteOperationInfo writeOperationInfo,
-      final Supplier<ListenableFuture<T>> secondaryResultFutureCaller,
+      final Supplier<ListenableFuture<T>> secondaryResultFutureSupplier,
       final FlowController flowController) {
     this.referenceCounter.holdReferenceUntilCompletion(
         RequestScheduling.scheduleVerificationAndRequestWithFlowControl(
             writeOperationInfo.requestResourcesDescription,
-            secondaryResultFutureCaller,
+            secondaryResultFutureSupplier,
             new FutureCallback<T>() {
               @Override
               public void onSuccess(@NullableDecl T t) {}

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/MirroringTable.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/MirroringTable.java
@@ -25,6 +25,7 @@ import com.google.cloud.bigtable.mirroring.hbase1_x.utils.flowcontrol.FlowContro
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.flowcontrol.RequestResourcesDescription;
 import com.google.cloud.bigtable.mirroring.hbase1_x.verification.MismatchDetector;
 import com.google.cloud.bigtable.mirroring.hbase1_x.verification.VerificationContinuationFactory;
+import com.google.common.base.Supplier;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -34,7 +35,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.Cell;
@@ -547,7 +547,7 @@ public class MirroringTable implements Table, ListenableCloseable {
 
   private <T> void scheduleVerificationAndRequestWithFlowControl(
       final RequestResourcesDescription resultInfo,
-      final Callable<ListenableFuture<T>> secondaryGetFutureCaller,
+      final Supplier<ListenableFuture<T>> secondaryGetFutureCaller,
       final FutureCallback<T> verificationCallback) {
     this.referenceCounter.holdReferenceUntilCompletion(
         RequestScheduling.scheduleVerificationAndRequestWithFlowControl(
@@ -556,7 +556,7 @@ public class MirroringTable implements Table, ListenableCloseable {
 
   public <T> void scheduleWriteWithControlFlow(
       final WriteOperationInfo writeOperationInfo,
-      final Callable<ListenableFuture<T>> secondaryResultFutureCaller,
+      final Supplier<ListenableFuture<T>> secondaryResultFutureCaller,
       final FlowController flowController) {
     this.referenceCounter.holdReferenceUntilCompletion(
         RequestScheduling.scheduleVerificationAndRequestWithFlowControl(

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/MirroringTable.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/MirroringTable.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.Cell;
@@ -546,21 +547,21 @@ public class MirroringTable implements Table, ListenableCloseable {
 
   private <T> void scheduleVerificationAndRequestWithFlowControl(
       final RequestResourcesDescription resultInfo,
-      final ListenableFuture<T> secondaryGetFuture,
+      final Callable<ListenableFuture<T>> secondaryGetFutureCaller,
       final FutureCallback<T> verificationCallback) {
     this.referenceCounter.holdReferenceUntilCompletion(
         RequestScheduling.scheduleVerificationAndRequestWithFlowControl(
-            resultInfo, secondaryGetFuture, verificationCallback, this.flowController));
+            resultInfo, secondaryGetFutureCaller, verificationCallback, this.flowController));
   }
 
   public <T> void scheduleWriteWithControlFlow(
       final WriteOperationInfo writeOperationInfo,
-      final ListenableFuture<T> secondaryResultFuture,
+      final Callable<ListenableFuture<T>> secondaryResultFutureCaller,
       final FlowController flowController) {
     this.referenceCounter.holdReferenceUntilCompletion(
         RequestScheduling.scheduleVerificationAndRequestWithFlowControl(
             writeOperationInfo.requestResourcesDescription,
-            secondaryResultFuture,
+            secondaryResultFutureCaller,
             new FutureCallback<T>() {
               @Override
               public void onSuccess(@NullableDecl T t) {}

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/asyncwrappers/AsyncResultScannerWrapper.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/asyncwrappers/AsyncResultScannerWrapper.java
@@ -35,6 +35,8 @@ import org.apache.hadoop.hbase.client.Table;
  * {@link MirroringResultScanner} schedules asynchronous next()s after synchronous operations to
  * verify consistency. HBase doesn't provide any Asynchronous API for Scanners thus we wrap
  * ResultScanner into AsyncResultScannerWrapper to enable async operations on scanners.
+ *
+ * <p>Note that next() method returns a Supplier<> as its result is used only in callbacks
  */
 @InternalApi("For internal usage only")
 public class AsyncResultScannerWrapper implements ListenableCloseable {

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/asyncwrappers/AsyncResultScannerWrapper.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/asyncwrappers/AsyncResultScannerWrapper.java
@@ -71,7 +71,8 @@ public class AsyncResultScannerWrapper implements ListenableCloseable {
     this.nextContextQueue = new ConcurrentLinkedQueue<>();
   }
 
-  public Supplier<ListenableFuture<AsyncScannerVerificationPayload>> next(final ScannerRequestContext context) {
+  public Supplier<ListenableFuture<AsyncScannerVerificationPayload>> next(
+      final ScannerRequestContext context) {
     return new Supplier<ListenableFuture<AsyncScannerVerificationPayload>>() {
       @Override
       public ListenableFuture<AsyncScannerVerificationPayload> get() {

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/asyncwrappers/AsyncTableWrapper.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/asyncwrappers/AsyncTableWrapper.java
@@ -70,56 +70,76 @@ public class AsyncTableWrapper implements ListenableCloseable {
     this.pendingOperationsReferenceCounter = new ListenableReferenceCounter();
   }
 
-  public ListenableFuture<Result> get(final Get gets) {
-    return submitTask(
-        new Callable<Result>() {
-          @Override
-          public Result call() throws Exception {
-            synchronized (table) {
-              Log.trace("get(Get)");
-              return table.get(gets);
-            }
-          }
-        });
+  public Callable<ListenableFuture<Result>> get(final Get gets) {
+    return new Callable<ListenableFuture<Result>>() {
+      @Override
+      public ListenableFuture<Result> call() {
+        return submitTask(
+            new Callable<Result>() {
+              @Override
+              public Result call() throws IOException {
+                synchronized (table) {
+                  Log.trace("get(Get)");
+                  return table.get(gets);
+                }
+              }
+            });
+      }
+    };
   }
 
-  public ListenableFuture<Result[]> get(final List<Get> gets) {
-    return submitTask(
-        new Callable<Result[]>() {
-          @Override
-          public Result[] call() throws Exception {
-            synchronized (table) {
-              Log.trace("get(List<Get>)");
-              return table.get(gets);
-            }
-          }
-        });
+  public Callable<ListenableFuture<Result[]>> get(final List<Get> gets) {
+    return new Callable<ListenableFuture<Result[]>>() {
+      @Override
+      public ListenableFuture<Result[]> call() {
+        return submitTask(
+            new Callable<Result[]>() {
+              @Override
+              public Result[] call() throws IOException {
+                synchronized (table) {
+                  Log.trace("get(List<Get>)");
+                  return table.get(gets);
+                }
+              }
+            });
+      }
+    };
   }
 
-  public ListenableFuture<Boolean> exists(final Get get) {
-    return submitTask(
-        new Callable<Boolean>() {
-          @Override
-          public Boolean call() throws Exception {
-            synchronized (table) {
-              Log.trace("exists(Get)");
-              return table.exists(get);
-            }
-          }
-        });
+  public Callable<ListenableFuture<Boolean>> exists(final Get get) {
+    return new Callable<ListenableFuture<Boolean>>() {
+      @Override
+      public ListenableFuture<Boolean> call() {
+        return submitTask(
+            new Callable<Boolean>() {
+              @Override
+              public Boolean call() throws IOException {
+                synchronized (table) {
+                  Log.trace("exists(Get)");
+                  return table.exists(get);
+                }
+              }
+            });
+      }
+    };
   }
 
-  public ListenableFuture<boolean[]> existsAll(final List<Get> gets) {
-    return submitTask(
-        new Callable<boolean[]>() {
-          @Override
-          public boolean[] call() throws Exception {
-            synchronized (table) {
-              Log.trace("existsAll(List<Get>)");
-              return table.existsAll(gets);
-            }
-          }
-        });
+  public Callable<ListenableFuture<boolean[]>> existsAll(final List<Get> gets) {
+    return new Callable<ListenableFuture<boolean[]>>() {
+      @Override
+      public ListenableFuture<boolean[]> call() {
+        return submitTask(
+            new Callable<boolean[]>() {
+              @Override
+              public boolean[] call() throws IOException {
+                synchronized (table) {
+                  Log.trace("existsAll(List<Get>)");
+                  return table.existsAll(gets);
+                }
+              }
+            });
+      }
+    };
   }
 
   public synchronized ListenableFuture<Void> asyncClose() {
@@ -170,95 +190,125 @@ public class AsyncTableWrapper implements ListenableCloseable {
     return future;
   }
 
-  public ListenableFuture<Void> put(final Put put) {
-    return submitTask(
-        new Callable<Void>() {
-          @Override
-          public Void call() throws IOException {
-            synchronized (table) {
-              Log.trace("put(Put)");
-              table.put(put);
-            }
-            return null;
-          }
-        });
-  }
-
-  public ListenableFuture<Void> append(final Append append) {
-    return submitTask(
-        new Callable<Void>() {
-          @Override
-          public Void call() throws IOException {
-            synchronized (table) {
-              Log.trace("append(Append)");
-              table.append(append);
-            }
-            return null;
-          }
-        });
-  }
-
-  public ListenableFuture<Void> increment(final Increment increment) {
-    return submitTask(
-        new Callable<Void>() {
-          @Override
-          public Void call() throws IOException {
-            synchronized (table) {
-              Log.trace("increment(Increment)");
-              table.increment(increment);
-            }
-            return null;
-          }
-        });
-  }
-
-  public ListenableFuture<Void> mutateRow(final RowMutations rowMutations) {
-    return submitTask(
-        new Callable<Void>() {
-          @Override
-          public Void call() throws IOException {
-            synchronized (table) {
-              Log.trace("mutateRow(RowMutations)");
-              table.mutateRow(rowMutations);
-            }
-            return null;
-          }
-        });
-  }
-
-  public ListenableFuture<Void> delete(final Delete delete) {
-    return submitTask(
-        new Callable<Void>() {
-          @Override
-          public Void call() throws IOException {
-            synchronized (table) {
-              Log.trace("delete(Delete)");
-              table.delete(delete);
-            }
-            return null;
-          }
-        });
-  }
-
-  public ListenableFuture<Void> batch(
-      final List<? extends Row> operations, final Object[] results) {
-    return submitTask(
-        new Callable<Void>() {
-          @Override
-          public Void call() throws IOException {
-            synchronized (table) {
-              try {
-                Log.trace("batch(List<Row>, Object[])");
-                table.batch(operations, results);
-              } catch (InterruptedException e) {
-                IOException exception = new InterruptedIOException();
-                exception.initCause(e);
-                throw exception;
+  public Callable<ListenableFuture<Void>> put(final Put put) {
+    return new Callable<ListenableFuture<Void>>() {
+      @Override
+      public ListenableFuture<Void> call() {
+        return submitTask(
+            new Callable<Void>() {
+              @Override
+              public Void call() throws IOException {
+                synchronized (table) {
+                  Log.trace("put(Put)");
+                  table.put(put);
+                }
+                return null;
               }
-            }
-            return null;
-          }
-        });
+            });
+      }
+    };
+  }
+
+  public Callable<ListenableFuture<Void>> append(final Append append) {
+    return new Callable<ListenableFuture<Void>>() {
+      @Override
+      public ListenableFuture<Void> call() {
+        return submitTask(
+            new Callable<Void>() {
+              @Override
+              public Void call() throws IOException {
+                synchronized (table) {
+                  Log.trace("append(Append)");
+                  table.append(append);
+                }
+                return null;
+              }
+            });
+      }
+    };
+  }
+
+  public Callable<ListenableFuture<Void>> increment(final Increment increment) {
+    return new Callable<ListenableFuture<Void>>() {
+      @Override
+      public ListenableFuture<Void> call() {
+        return submitTask(
+            new Callable<Void>() {
+              @Override
+              public Void call() throws IOException {
+                synchronized (table) {
+                  Log.trace("increment(Increment)");
+                  table.increment(increment);
+                }
+                return null;
+              }
+            });
+      }
+    };
+  }
+
+  public Callable<ListenableFuture<Void>> mutateRow(final RowMutations rowMutations) {
+    return new Callable<ListenableFuture<Void>>() {
+      @Override
+      public ListenableFuture<Void> call() {
+        return submitTask(
+            new Callable<Void>() {
+              @Override
+              public Void call() throws IOException {
+                synchronized (table) {
+                  Log.trace("mutateRow(RowMutations)");
+                  table.mutateRow(rowMutations);
+                }
+                return null;
+              }
+            });
+      }
+    };
+  }
+
+  public Callable<ListenableFuture<Void>> delete(final Delete delete) {
+    return new Callable<ListenableFuture<Void>>() {
+      @Override
+      public ListenableFuture<Void> call() {
+        return submitTask(
+            new Callable<Void>() {
+              @Override
+              public Void call() throws IOException {
+                synchronized (table) {
+                  Log.trace("delete(Delete)");
+                  table.delete(delete);
+                }
+                return null;
+              }
+            });
+      }
+    };
+  }
+
+  public Callable<ListenableFuture<Void>> batch(
+      final List<? extends Row> operations, final Object[] results) {
+    return new Callable<ListenableFuture<Void>>() {
+      @Override
+      public ListenableFuture<Void> call() {
+        return submitTask(
+            new Callable<Void>() {
+              @Override
+              public Void call() throws IOException {
+                synchronized (table) {
+                  try {
+                    Log.trace("batch(List<Row>, Object[])");
+                    table.batch(operations, results);
+                  } catch (InterruptedException e) {
+                    IOException exception = new InterruptedIOException();
+                    exception.initCause(e);
+                    throw exception;
+                  }
+                }
+                return null;
+              }
+            });
+      }
+    };
   }
 
   @Override

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/asyncwrappers/AsyncTableWrapper.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/asyncwrappers/AsyncTableWrapper.java
@@ -46,6 +46,9 @@ import org.apache.hadoop.hbase.client.Table;
  *
  * <p>Table instances are not thread-safe, every operation is synchronized to prevent concurrent
  * accesses to the table from different threads in the executor.
+ *
+ * <p>Note that the most of the class' interface is wrapped in Supplier<> as the results are only
+ * used in callbacks.
  */
 @InternalApi("For internal usage only")
 public class AsyncTableWrapper implements ListenableCloseable {

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/asyncwrappers/AsyncTableWrapper.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/asyncwrappers/AsyncTableWrapper.java
@@ -19,6 +19,7 @@ import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.ListenableCloseable;
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.ListenableReferenceCounter;
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.Logger;
+import com.google.common.base.Supplier;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -70,76 +71,56 @@ public class AsyncTableWrapper implements ListenableCloseable {
     this.pendingOperationsReferenceCounter = new ListenableReferenceCounter();
   }
 
-  public Callable<ListenableFuture<Result>> get(final Get gets) {
-    return new Callable<ListenableFuture<Result>>() {
-      @Override
-      public ListenableFuture<Result> call() {
-        return submitTask(
-            new Callable<Result>() {
-              @Override
-              public Result call() throws IOException {
-                synchronized (table) {
-                  Log.trace("get(Get)");
-                  return table.get(gets);
-                }
-              }
-            });
-      }
-    };
+  public Supplier<ListenableFuture<Result>> get(final Get gets) {
+    return createSubmitTaskSupplier(
+        new Callable<Result>() {
+          @Override
+          public Result call() throws Exception {
+            synchronized (table) {
+              Log.trace("get(Get)");
+              return table.get(gets);
+            }
+          }
+        });
   }
 
-  public Callable<ListenableFuture<Result[]>> get(final List<Get> gets) {
-    return new Callable<ListenableFuture<Result[]>>() {
-      @Override
-      public ListenableFuture<Result[]> call() {
-        return submitTask(
-            new Callable<Result[]>() {
-              @Override
-              public Result[] call() throws IOException {
-                synchronized (table) {
-                  Log.trace("get(List<Get>)");
-                  return table.get(gets);
-                }
-              }
-            });
-      }
-    };
+  public Supplier<ListenableFuture<Result[]>> get(final List<Get> gets) {
+    return createSubmitTaskSupplier(
+        new Callable<Result[]>() {
+          @Override
+          public Result[] call() throws Exception {
+            synchronized (table) {
+              Log.trace("get(List<Get>)");
+              return table.get(gets);
+            }
+          }
+        });
   }
 
-  public Callable<ListenableFuture<Boolean>> exists(final Get get) {
-    return new Callable<ListenableFuture<Boolean>>() {
-      @Override
-      public ListenableFuture<Boolean> call() {
-        return submitTask(
-            new Callable<Boolean>() {
-              @Override
-              public Boolean call() throws IOException {
-                synchronized (table) {
-                  Log.trace("exists(Get)");
-                  return table.exists(get);
-                }
-              }
-            });
-      }
-    };
+  public Supplier<ListenableFuture<Boolean>> exists(final Get get) {
+    return createSubmitTaskSupplier(
+        new Callable<Boolean>() {
+          @Override
+          public Boolean call() throws Exception {
+            synchronized (table) {
+              Log.trace("exists(Get)");
+              return table.exists(get);
+            }
+          }
+        });
   }
 
-  public Callable<ListenableFuture<boolean[]>> existsAll(final List<Get> gets) {
-    return new Callable<ListenableFuture<boolean[]>>() {
-      @Override
-      public ListenableFuture<boolean[]> call() {
-        return submitTask(
-            new Callable<boolean[]>() {
-              @Override
-              public boolean[] call() throws IOException {
-                synchronized (table) {
-                  Log.trace("existsAll(List<Get>)");
-                  return table.existsAll(gets);
-                }
-              }
-            });
-      }
-    };
+  public Supplier<ListenableFuture<boolean[]>> existsAll(final List<Get> gets) {
+    return createSubmitTaskSupplier(
+        new Callable<boolean[]>() {
+          @Override
+          public boolean[] call() throws Exception {
+            synchronized (table) {
+              Log.trace("existsAll(List<Get>)");
+              return table.existsAll(gets);
+            }
+          }
+        });
   }
 
   public synchronized ListenableFuture<Void> asyncClose() {
@@ -184,131 +165,110 @@ public class AsyncTableWrapper implements ListenableCloseable {
     return result;
   }
 
+  public <T> Supplier<ListenableFuture<T>> createSubmitTaskSupplier(final Callable<T> task) {
+    return new Supplier<ListenableFuture<T>>() {
+      @Override
+      public ListenableFuture<T> get() {
+        return submitTask(task);
+      }
+    };
+  }
+
   public <T> ListenableFuture<T> submitTask(Callable<T> task) {
     ListenableFuture<T> future = this.executorService.submit(task);
     this.pendingOperationsReferenceCounter.holdReferenceUntilCompletion(future);
     return future;
   }
 
-  public Callable<ListenableFuture<Void>> put(final Put put) {
-    return new Callable<ListenableFuture<Void>>() {
-      @Override
-      public ListenableFuture<Void> call() {
-        return submitTask(
-            new Callable<Void>() {
-              @Override
-              public Void call() throws IOException {
-                synchronized (table) {
-                  Log.trace("put(Put)");
-                  table.put(put);
-                }
-                return null;
-              }
-            });
-      }
-    };
+  public Supplier<ListenableFuture<Void>> put(final Put put) {
+    return createSubmitTaskSupplier(
+        new Callable<Void>() {
+          @Override
+          public Void call() throws IOException {
+            synchronized (table) {
+              Log.trace("put(Put)");
+              table.put(put);
+            }
+            return null;
+          }
+        });
   }
 
-  public Callable<ListenableFuture<Void>> append(final Append append) {
-    return new Callable<ListenableFuture<Void>>() {
-      @Override
-      public ListenableFuture<Void> call() {
-        return submitTask(
-            new Callable<Void>() {
-              @Override
-              public Void call() throws IOException {
-                synchronized (table) {
-                  Log.trace("append(Append)");
-                  table.append(append);
-                }
-                return null;
-              }
-            });
-      }
-    };
+  public Supplier<ListenableFuture<Void>> append(final Append append) {
+    return createSubmitTaskSupplier(
+        new Callable<Void>() {
+          @Override
+          public Void call() throws IOException {
+            synchronized (table) {
+              Log.trace("append(Append)");
+              table.append(append);
+            }
+            return null;
+          }
+        });
   }
 
-  public Callable<ListenableFuture<Void>> increment(final Increment increment) {
-    return new Callable<ListenableFuture<Void>>() {
-      @Override
-      public ListenableFuture<Void> call() {
-        return submitTask(
-            new Callable<Void>() {
-              @Override
-              public Void call() throws IOException {
-                synchronized (table) {
-                  Log.trace("increment(Increment)");
-                  table.increment(increment);
-                }
-                return null;
-              }
-            });
-      }
-    };
+  public Supplier<ListenableFuture<Void>> increment(final Increment increment) {
+    return createSubmitTaskSupplier(
+        new Callable<Void>() {
+          @Override
+          public Void call() throws IOException {
+            synchronized (table) {
+              Log.trace("increment(Increment)");
+              table.increment(increment);
+            }
+            return null;
+          }
+        });
   }
 
-  public Callable<ListenableFuture<Void>> mutateRow(final RowMutations rowMutations) {
-    return new Callable<ListenableFuture<Void>>() {
-      @Override
-      public ListenableFuture<Void> call() {
-        return submitTask(
-            new Callable<Void>() {
-              @Override
-              public Void call() throws IOException {
-                synchronized (table) {
-                  Log.trace("mutateRow(RowMutations)");
-                  table.mutateRow(rowMutations);
-                }
-                return null;
-              }
-            });
-      }
-    };
+  public Supplier<ListenableFuture<Void>> mutateRow(final RowMutations rowMutations) {
+    return createSubmitTaskSupplier(
+        new Callable<Void>() {
+          @Override
+          public Void call() throws IOException {
+            synchronized (table) {
+              Log.trace("mutateRow(RowMutations)");
+              table.mutateRow(rowMutations);
+            }
+            return null;
+          }
+        });
   }
 
-  public Callable<ListenableFuture<Void>> delete(final Delete delete) {
-    return new Callable<ListenableFuture<Void>>() {
-      @Override
-      public ListenableFuture<Void> call() {
-        return submitTask(
-            new Callable<Void>() {
-              @Override
-              public Void call() throws IOException {
-                synchronized (table) {
-                  Log.trace("delete(Delete)");
-                  table.delete(delete);
-                }
-                return null;
-              }
-            });
-      }
-    };
+  public Supplier<ListenableFuture<Void>> delete(final Delete delete) {
+    return createSubmitTaskSupplier(
+        new Callable<Void>() {
+          @Override
+          public Void call() throws IOException {
+            synchronized (table) {
+              Log.trace("delete(Delete)");
+              table.delete(delete);
+            }
+            return null;
+          }
+        });
   }
 
-  public Callable<ListenableFuture<Void>> batch(
+  public Supplier<ListenableFuture<Void>> batch(
       final List<? extends Row> operations, final Object[] results) {
-    return new Callable<ListenableFuture<Void>>() {
-      @Override
-      public ListenableFuture<Void> call() {
-        return submitTask(
-            new Callable<Void>() {
-              @Override
-              public Void call() throws IOException {
-                synchronized (table) {
-                  try {
-                    Log.trace("batch(List<Row>, Object[])");
-                    table.batch(operations, results);
-                  } catch (InterruptedException e) {
-                    IOException exception = new InterruptedIOException();
-                    exception.initCause(e);
-                    throw exception;
-                  }
-                }
-                return null;
+    return createSubmitTaskSupplier(
+        new Callable<Void>() {
+          @Override
+          public Void call() throws IOException {
+            synchronized (table) {
+              try {
+                Log.trace("batch(List<Row>, Object[])");
+                table.batch(operations, results);
+              } catch (InterruptedException e) {
+                IOException exception = new InterruptedIOException();
+                exception.initCause(e);
+                throw exception;
               }
-            });
-      }
-    };
+            }
+            return null;
+          }
+        });
   }
 
   @Override

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/RequestScheduling.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/RequestScheduling.java
@@ -38,7 +38,7 @@ public class RequestScheduling {
 
   public static <T> ListenableFuture<Void> scheduleVerificationAndRequestWithFlowControl(
       final RequestResourcesDescription requestResourcesDescription,
-      final Supplier<ListenableFuture<T>> secondaryResultFutureCaller,
+      final Supplier<ListenableFuture<T>> secondaryResultFutureSupplier,
       final FutureCallback<T> verificationCallback,
       final FlowController flowController) {
     final SettableFuture<Void> verificationCompletedFuture = SettableFuture.create();
@@ -48,7 +48,7 @@ public class RequestScheduling {
     try {
       final ResourceReservation reservation = reservationRequest.get();
       Futures.addCallback(
-          secondaryResultFutureCaller.get(),
+          secondaryResultFutureSupplier.get(),
           new FutureCallback<T>() {
             @Override
             public void onSuccess(@NullableDecl T t) {

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/RequestScheduling.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/RequestScheduling.java
@@ -25,7 +25,6 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase1_x/asyncwrappers/TestMirroringResultScanner.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase1_x/asyncwrappers/TestMirroringResultScanner.java
@@ -306,12 +306,12 @@ public class TestMirroringResultScanner {
     ScannerRequestContext c5 = new ScannerRequestContext(null, null, 5);
     ScannerRequestContext c6 = new ScannerRequestContext(null, null, 6);
 
-    catchResult(asyncResultScannerWrapper.next(c1), calls);
-    catchResult(asyncResultScannerWrapper.next(c2), calls);
-    catchResult(asyncResultScannerWrapper.next(c3), calls);
-    catchResult(asyncResultScannerWrapper.next(c4), calls);
-    catchResult(asyncResultScannerWrapper.next(c5), calls);
-    catchResult(asyncResultScannerWrapper.next(c6), calls);
+    catchResult(asyncResultScannerWrapper.next(c1).get(), calls);
+    catchResult(asyncResultScannerWrapper.next(c2).get(), calls);
+    catchResult(asyncResultScannerWrapper.next(c3).get(), calls);
+    catchResult(asyncResultScannerWrapper.next(c4).get(), calls);
+    catchResult(asyncResultScannerWrapper.next(c5).get(), calls);
+    catchResult(asyncResultScannerWrapper.next(c6).get(), calls);
 
     reverseOrderExecutorService.callCallables();
 


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unoperate/java-bigtable-hbase-1/4)
<!-- Reviewable:end -->

This PR introduces delay of requests to the secondary database by requiring that functions pass `Callable<Future>` instead of `Future`. This `Callable` will be also used to complete `Future`s in 2.x API too.