### PR TITLE
fix: RequestScheduling should handle rejected resource reservations

### DIFF
--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/MirroringTable.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/MirroringTable.java
@@ -602,7 +602,13 @@ public class MirroringTable implements Table, ListenableCloseable {
                 secondaryWriteErrorConsumer.consume(writeOperationInfo.operations);
               }
             },
-            flowController));
+            flowController,
+            new Runnable() {
+              @Override
+              public void run() {
+                secondaryWriteErrorConsumer.consume(writeOperationInfo.operations);
+              }
+            }));
   }
 
   private void scheduleSecondaryWriteBatchOperations(
@@ -631,7 +637,13 @@ public class MirroringTable implements Table, ListenableCloseable {
         this.secondaryAsyncWrapper.batch(
             primarySplitResponse.allSuccessfulOperations, resultsSecondary),
         verificationFuture,
-        this.flowController);
+        this.flowController,
+        new Runnable() {
+          @Override
+          public void run() {
+            secondaryWriteErrorConsumer.consume(primarySplitResponse.successfulWrites);
+          }
+        });
   }
 
   public static class WriteOperationInfo {

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/flowcontrol/TestFlowController.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/flowcontrol/TestFlowController.java
@@ -236,4 +236,14 @@ public class TestFlowController {
     FlowController.cancelRequest(grantedFuture);
     verify(reservation, never()).release();
   }
+
+  @Test
+  public void testCancellingRejectedReservationFuture() {
+    ResourceReservation reservation = mock(ResourceReservation.class);
+    SettableFuture<ResourceReservation> notGrantedFuture = SettableFuture.create();
+    notGrantedFuture.setException(new Exception("test"));
+
+    FlowController.cancelRequest(notGrantedFuture);
+    verify(reservation, never()).release();
+  }
 }


### PR DESCRIPTION
Custom FlowControlerStrategy implementations might, contrary to the
default implementation, resolve reservation requests with exception,
what we should handle by not performing the action that had to acquire
the resources.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unoperate/java-bigtable-hbase-1/24)
<!-- Reviewable:end -->
