### PR TITLE
refactor: make MirroringAsync{Connection,Table} use SecondaryWriteErrorConsumerWithMetrics

### DIFF
--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/BatchHelpers.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/BatchHelpers.java
@@ -88,10 +88,12 @@ public class BatchHelpers {
                   resultIsFaultyPredicate);
 
           try (Scope scope = mirroringTracer.spanFactory.verificationScope()) {
-            mismatchDetector.batch(
-                secondarySplitResponse.successfulReads,
-                matchingSuccessfulReads.primaryResults,
-                matchingSuccessfulReads.secondaryResults);
+            if (!matchingSuccessfulReads.successfulReads.isEmpty()) {
+              mismatchDetector.batch(
+                  secondarySplitResponse.successfulReads,
+                  matchingSuccessfulReads.primaryResults,
+                  matchingSuccessfulReads.secondaryResults);
+            }
 
             if (!matchingSuccessfulReads.failedReads.isEmpty()) {
               mismatchDetector.batch(matchingSuccessfulReads.failedReads, throwable);


### PR DESCRIPTION
Make MirroringAsync{Connection,Table} use SecondaryWriteErrorConsumerWithMetrics

old: In preparation for `MirroringAsyncTable#batch()` which uses BatchHelpers, which use `SecondaryWriteErrorConsumerWithMetrics` and new AsyncRequestScheduling API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unoperate/java-bigtable-hbase-1/36)
<!-- Reviewable:end -->
