### PR TITLE
refactor: make AsyncRequestScheduling accept CompletableFuture<ResourceReservation>

### DIFF
--- a/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase2_x/TestMirroringAsyncTable.java
+++ b/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase2_x/TestMirroringAsyncTable.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.when;
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.SecondaryWriteErrorConsumerWithMetrics;
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.flowcontrol.FlowController;
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.flowcontrol.RequestResourcesDescription;
-import com.google.cloud.bigtable.mirroring.hbase1_x.utils.mirroringmetrics.MirroringSpanConstants;
+import com.google.cloud.bigtable.mirroring.hbase1_x.utils.mirroringmetrics.MirroringSpanConstants.HBaseOperation;
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.mirroringmetrics.MirroringTracer;
 import com.google.cloud.bigtable.mirroring.hbase1_x.verification.MismatchDetector;
 import com.google.common.primitives.Longs;
@@ -278,7 +278,7 @@ public class TestMirroringAsyncTable {
 
     ArgumentCaptor<List<Row>> argument = ArgumentCaptor.forClass(List.class);
     verify(secondaryWriteErrorConsumer, times(1))
-        .consume(eq(MirroringSpanConstants.HBaseOperation.PUT), argument.capture());
+        .consume(eq(HBaseOperation.PUT), argument.capture());
     assertThat(argument.getValue().size()).isEqualTo(1);
     assertThat(argument.getValue().get(0)).isEqualTo(put);
   }


### PR DESCRIPTION
Prepare AsyncRequestScheduling for `MirroringAsyncTable#batch()`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unoperate/java-bigtable-hbase-1/39)
<!-- Reviewable:end -->
