### PR TITLE
refactor: remove redundant writeWithControlFlow argument

### DIFF
--- a/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase2_x/TestMirroringAsyncTable.java
+++ b/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase2_x/TestMirroringAsyncTable.java
@@ -299,12 +299,7 @@ public class TestMirroringAsyncTable {
 
     verify(primaryTable, times(1)).put(put);
     verify(secondaryTable, times(1)).put(put);
-
-    ArgumentCaptor<List<Row>> argument = ArgumentCaptor.forClass(List.class);
-    verify(secondaryWriteErrorConsumer, times(1))
-        .consume(eq(HBaseOperation.PUT), argument.capture());
-    assertThat(argument.getValue().size()).isEqualTo(1);
-    assertThat(argument.getValue().get(0)).isEqualTo(put);
+    verify(secondaryWriteErrorConsumer, times(1)).consume(HBaseOperation.PUT, put);
   }
 
   <T> List<T> waitForAll(List<CompletableFuture<T>> futures) {


### PR DESCRIPTION
[info, not a commit message]
When rebasing batch() patch after merging OpenCensus into master I introduced a redundant argument not having noticed that both the error handlers are the same.
This PR removes this redundant argument in preparation for cleaner implementation of Increment/Append as a Put.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unoperate/java-bigtable-hbase-1/44)
<!-- Reviewable:end -->
