### PR TITLE
feat: implement async result scanner

### DIFF
--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/MirroringResultScanner.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/MirroringResultScanner.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.mirroring.hbase1_x;
+
+import com.google.api.core.InternalApi;
+import com.google.cloud.bigtable.mirroring.hbase1_x.asyncwrappers.AsyncResultScannerWrapper;
+import com.google.cloud.bigtable.mirroring.hbase1_x.verification.VerificationContinuationFactory;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.MoreExecutors;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.hbase.client.AbstractClientScanner;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.ResultScanner;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.client.metrics.ScanMetrics;
+
+/**
+ * {@link ResultScanner} that performs reads on two underlying tables.
+ *
+ * <p>Every read is performed synchronously on `ResultScanner` from primary `Table` and then, if it
+ * succeeded, asynchronously on secondary `ResultScanner`.
+ */
+@InternalApi("For internal usage only")
+public class MirroringResultScanner extends AbstractClientScanner {
+  private static final Log log = LogFactory.getLog(MirroringTable.class);
+
+  private Scan originalScan;
+  private ResultScanner primaryResultScanner;
+  private AsyncResultScannerWrapper secondaryResultScannerWrapper;
+  private VerificationContinuationFactory verificationContinuationFactory;
+  /**
+   * Keeps track of number of entries already read from this scanner to provide context for
+   * MismatchDetectors.
+   */
+  private int readEntries;
+
+  public MirroringResultScanner(
+      Scan originalScan,
+      ResultScanner primaryResultScanner,
+      AsyncResultScannerWrapper secondaryResultScannerWrapper,
+      VerificationContinuationFactory verificationContinuationFactory) {
+    this.originalScan = originalScan;
+    this.primaryResultScanner = primaryResultScanner;
+    this.secondaryResultScannerWrapper = secondaryResultScannerWrapper;
+    this.verificationContinuationFactory = verificationContinuationFactory;
+    this.readEntries = 0;
+  }
+
+  @Override
+  public Result next() throws IOException {
+    Result result = this.primaryResultScanner.next();
+    int startingIndex = this.readEntries;
+    this.readEntries += 1;
+    Futures.addCallback(
+        this.secondaryResultScannerWrapper.next(),
+        this.verificationContinuationFactory.scannerNext(this.originalScan, startingIndex, result),
+        MoreExecutors.directExecutor());
+    return result;
+  }
+
+  @Override
+  public Result[] next(int entriesToRead) throws IOException {
+    Result[] results = this.primaryResultScanner.next(entriesToRead);
+    int startingIndex = this.readEntries;
+    this.readEntries += entriesToRead;
+    Futures.addCallback(
+        this.secondaryResultScannerWrapper.next(entriesToRead),
+        this.verificationContinuationFactory.scannerNext(
+            this.originalScan, startingIndex, entriesToRead, results),
+        MoreExecutors.directExecutor());
+    return results;
+  }
+
+  @Override
+  public void close() {
+    RuntimeException firstException = null;
+    try {
+      this.primaryResultScanner.close();
+    } catch (RuntimeException e) {
+      firstException = e;
+    } finally {
+      try {
+        this.secondaryResultScannerWrapper.close();
+      } catch (RuntimeException e) {
+        log.error("Exception while scheduling secondaryResultScannerWrapper.close().", e);
+        if (firstException == null) {
+          firstException = e;
+        } else {
+          // Attach current exception as suppressed to make it visible in `firstException`s
+          // stacktrace.
+          firstException.addSuppressed(e);
+        }
+      }
+    }
+
+    if (firstException != null) {
+      throw firstException;
+    }
+  }
+
+  @Override
+  public boolean renewLease() {
+    boolean primaryLease = this.primaryResultScanner.renewLease();
+    if (!primaryLease) {
+      return false;
+    }
+
+    try {
+      return this.secondaryResultScannerWrapper.renewLease().get();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return false;
+    } catch (ExecutionException e) {
+      log.error("Execution exception in secondaryResultScannerWrapper.renewLease().", e.getCause());
+      return false;
+    } catch (Exception e) {
+      log.error("Exception while scheduling secondaryResultScannerWrapper.renewLease().", e);
+      return false;
+    }
+  }
+
+  @Override
+  public ScanMetrics getScanMetrics() {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/MirroringTable.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/MirroringTable.java
@@ -16,6 +16,7 @@
 package com.google.cloud.bigtable.mirroring.hbase1_x;
 
 import com.google.api.core.InternalApi;
+import com.google.cloud.bigtable.mirroring.hbase1_x.asyncwrappers.AsyncTableWrapper;
 import com.google.cloud.bigtable.mirroring.hbase1_x.verification.MismatchDetector;
 import com.google.cloud.bigtable.mirroring.hbase1_x.verification.VerificationContinuationFactory;
 import com.google.common.util.concurrent.Futures;
@@ -160,17 +161,30 @@ public class MirroringTable implements Table {
 
   @Override
   public ResultScanner getScanner(Scan scan) throws IOException {
-    throw new UnsupportedOperationException();
+    return new MirroringResultScanner(
+        scan,
+        this.primaryTable.getScanner(scan),
+        this.secondaryAsyncWrapper.getScanner(scan),
+        this.verificationContinuationFactory);
   }
 
   @Override
-  public ResultScanner getScanner(byte[] bytes) throws IOException {
-    throw new UnsupportedOperationException();
+  public ResultScanner getScanner(byte[] family) throws IOException {
+    return getScanner(new Scan().addFamily(family));
   }
 
   @Override
-  public ResultScanner getScanner(byte[] bytes, byte[] bytes1) throws IOException {
-    throw new UnsupportedOperationException();
+  public ResultScanner getScanner(byte[] family, byte[] qualifier) throws IOException {
+    return getScanner(new Scan().addColumn(family, qualifier));
+  }
+
+  @Override
+  public void close() throws IOException {
+    try {
+      this.primaryTable.close();
+    } finally {
+      this.secondaryAsyncWrapper.close();
+    }
   }
 
   @Override
@@ -244,11 +258,6 @@ public class MirroringTable implements Table {
   public long incrementColumnValue(
       byte[] bytes, byte[] bytes1, byte[] bytes2, long l, Durability durability)
       throws IOException {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public void close() throws IOException {
     throw new UnsupportedOperationException();
   }
 

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/asyncwrappers/AsyncTableWrapper.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/asyncwrappers/AsyncTableWrapper.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.mirroring.hbase1_x.asyncwrappers;
+
+import com.google.api.core.InternalApi;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.Callable;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.client.Table;
+
+/**
+ * MirroringClient verifies consistency between two databases asynchronously - after the results are
+ * delivered to the user. HBase Table object does not have an synchronous API, so we simulate it by
+ * wrapping the regular Table into AsyncTableWrapper.
+ *
+ * <p>Table instances are not thread-safe, every operation is synchronized to prevent concurrent
+ * accesses to the table from different threads in the executor.
+ */
+@InternalApi("For internal usage only")
+public class AsyncTableWrapper {
+  private final Table table;
+  private final ListeningExecutorService executorService;
+
+  public AsyncTableWrapper(Table table, ListeningExecutorService executorService) {
+    this.table = table;
+    this.executorService = executorService;
+  }
+
+  public ListenableFuture<Result> get(final Get gets) {
+    return this.executorService.submit(
+        new Callable<Result>() {
+          @Override
+          public Result call() throws Exception {
+            synchronized (table) {
+              return table.get(gets);
+            }
+          }
+        });
+  }
+
+  public ListenableFuture<Result[]> get(final List<Get> gets) {
+    return this.executorService.submit(
+        new Callable<Result[]>() {
+          @Override
+          public Result[] call() throws Exception {
+            synchronized (table) {
+              return table.get(gets);
+            }
+          }
+        });
+  }
+
+  public ListenableFuture<Boolean> exists(final Get get) {
+    return this.executorService.submit(
+        new Callable<Boolean>() {
+          @Override
+          public Boolean call() throws Exception {
+            synchronized (table) {
+              return table.exists(get);
+            }
+          }
+        });
+  }
+
+  public ListenableFuture<boolean[]> existsAll(final List<Get> gets) {
+    return this.executorService.submit(
+        new Callable<boolean[]>() {
+          @Override
+          public boolean[] call() throws Exception {
+            synchronized (table) {
+              return table.existsAll(gets);
+            }
+          }
+        });
+  }
+
+  public ListenableFuture<Void> close() {
+    // TODO(mwalkiewicz): There is a race condition here, we should wait until all scheduled
+    // operations are finished before closing the scanner.
+    return this.executorService.submit(
+        new Callable<Void>() {
+          @Override
+          public Void call() throws IOException {
+            synchronized (table) {
+              table.close();
+            }
+            return null;
+          }
+        });
+  }
+
+  public AsyncResultScannerWrapper getScanner(Scan scan) throws IOException {
+    return new AsyncResultScannerWrapper(
+        this.table, this.table.getScanner(scan), this.executorService);
+  }
+}

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/verification/DefaultMismatchDetector.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/verification/DefaultMismatchDetector.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.List;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.Scan;
 
 @InternalApi("For internal usage only")
 public class DefaultMismatchDetector implements MismatchDetector {
@@ -75,5 +76,38 @@ public class DefaultMismatchDetector implements MismatchDetector {
   @Override
   public void get(List<Get> request, Throwable throwable) {
     System.out.println("getAll failed");
+  }
+
+  @Override
+  public void scannerNext(Scan request, int entriesAlreadyRead, Result primary, Result secondary) {
+    if (!Comparators.resultsEqual(primary, secondary)) {
+      System.out.println("scan() mismatch");
+    }
+  }
+
+  @Override
+  public void scannerNext(Scan request, int entriesAlreadyRead, Throwable throwable) {
+    System.out.println("scan() failed");
+  }
+
+  @Override
+  public void scannerNext(
+      Scan request, int entriesAlreadyRead, Result[] primary, Result[] secondary) {
+    if (primary.length != secondary.length) {
+      System.out.println("scan(i) length mismatch");
+      return;
+    }
+
+    for (int i = 0; i < primary.length; i++) {
+      if (!Comparators.resultsEqual(primary[i], secondary[i])) {
+        System.out.println("scan(i) mismatch");
+      }
+    }
+  }
+
+  @Override
+  public void scannerNext(
+      Scan request, int entriesAlreadyRead, int entriesRequested, Throwable throwable) {
+    System.out.println("scan(i) failed");
   }
 }

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/verification/MismatchDetector.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/verification/MismatchDetector.java
@@ -18,6 +18,7 @@ package com.google.cloud.bigtable.mirroring.hbase1_x.verification;
 import java.util.List;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.Scan;
 
 /**
  * Detects mismatches between primary and secondary databases. User can provide own implementation
@@ -40,4 +41,12 @@ public interface MismatchDetector {
   void get(List<Get> request, Result[] primary, Result[] secondary);
 
   void get(List<Get> request, Throwable throwable);
+
+  void scannerNext(Scan request, int entriesAlreadyRead, Result primary, Result secondary);
+
+  void scannerNext(Scan request, int entriesAlreadyRead, Throwable throwable);
+
+  void scannerNext(Scan request, int entriesAlreadyRead, Result[] primary, Result[] secondary);
+
+  void scannerNext(Scan request, int entriesAlreadyRead, int entriesRequested, Throwable throwable);
 }

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/verification/VerificationContinuationFactory.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/verification/VerificationContinuationFactory.java
@@ -20,6 +20,7 @@ import com.google.common.util.concurrent.FutureCallback;
 import java.util.List;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.Scan;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 @InternalApi("For internal usage only")
@@ -84,6 +85,43 @@ public class VerificationContinuationFactory {
       @Override
       public void onFailure(Throwable throwable) {
         VerificationContinuationFactory.this.mismatchDetector.get(request, throwable);
+      }
+    };
+  }
+
+  public FutureCallback<Result> scannerNext(
+      final Scan request, final int entriesAlreadyRead, final Result expectation) {
+    return new FutureCallback<Result>() {
+      @Override
+      public void onSuccess(@NullableDecl Result secondary) {
+        VerificationContinuationFactory.this.mismatchDetector.scannerNext(
+            request, entriesAlreadyRead, expectation, secondary);
+      }
+
+      @Override
+      public void onFailure(Throwable throwable) {
+        VerificationContinuationFactory.this.mismatchDetector.scannerNext(
+            request, entriesAlreadyRead, throwable);
+      }
+    };
+  }
+
+  public FutureCallback<Result[]> scannerNext(
+      final Scan request,
+      final int entriesAlreadyRead,
+      final int entriesToRead,
+      final Result[] expectation) {
+    return new FutureCallback<Result[]>() {
+      @Override
+      public void onSuccess(@NullableDecl Result[] secondary) {
+        VerificationContinuationFactory.this.mismatchDetector.scannerNext(
+            request, entriesAlreadyRead, expectation, secondary);
+      }
+
+      @Override
+      public void onFailure(Throwable throwable) {
+        VerificationContinuationFactory.this.mismatchDetector.scannerNext(
+            request, entriesAlreadyRead, entriesToRead, throwable);
       }
     };
   }

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase1_x/asyncwrappers/TestMirroringResultScanner.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase1_x/asyncwrappers/TestMirroringResultScanner.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.mirroring.hbase1_x.asyncwrappers;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.google.cloud.bigtable.mirroring.hbase1_x.MirroringResultScanner;
+import com.google.cloud.bigtable.mirroring.hbase1_x.verification.VerificationContinuationFactory;
+import org.apache.hadoop.hbase.client.ResultScanner;
+import org.apache.hadoop.hbase.client.Scan;
+import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TestMirroringResultScanner {
+  @Test
+  public void testScannerCloseWhenFirstCloseThrows() {
+    ResultScanner primaryScannerMock = mock(ResultScanner.class);
+
+    VerificationContinuationFactory continuationFactoryMock =
+        mock(VerificationContinuationFactory.class);
+    AsyncResultScannerWrapper secondaryScannerMock = mock(AsyncResultScannerWrapper.class);
+    final ResultScanner mirroringScanner =
+        new MirroringResultScanner(
+            new Scan(), primaryScannerMock, secondaryScannerMock, continuationFactoryMock);
+
+    doThrow(new RuntimeException("first")).when(primaryScannerMock).close();
+
+    Exception thrown =
+        assertThrows(
+            RuntimeException.class,
+            new ThrowingRunnable() {
+              @Override
+              public void run() {
+                mirroringScanner.close();
+              }
+            });
+
+    verify(primaryScannerMock, times(1)).close();
+    verify(secondaryScannerMock, times(1)).close();
+    assertThat(thrown).hasMessageThat().contains("first");
+  }
+
+  @Test
+  public void testScannerCloseWhenSecondCloseThrows() {
+    ResultScanner primaryScannerMock = mock(ResultScanner.class);
+
+    VerificationContinuationFactory continuationFactoryMock =
+        mock(VerificationContinuationFactory.class);
+    AsyncResultScannerWrapper secondaryScannerWrapperMock = mock(AsyncResultScannerWrapper.class);
+    final ResultScanner mirroringScanner =
+        new MirroringResultScanner(
+            new Scan(), primaryScannerMock, secondaryScannerWrapperMock, continuationFactoryMock);
+
+    doThrow(new RuntimeException("second")).when(secondaryScannerWrapperMock).close();
+
+    Exception thrown =
+        assertThrows(
+            RuntimeException.class,
+            new ThrowingRunnable() {
+              @Override
+              public void run() {
+                mirroringScanner.close();
+              }
+            });
+
+    verify(primaryScannerMock, times(1)).close();
+    verify(secondaryScannerWrapperMock, times(1)).close();
+    assertThat(thrown).hasMessageThat().contains("second");
+  }
+
+  @Test
+  public void testScannerCloseWhenBothCloseThrow() {
+    ResultScanner primaryScannerMock = mock(ResultScanner.class);
+
+    VerificationContinuationFactory continuationFactoryMock =
+        mock(VerificationContinuationFactory.class);
+    AsyncResultScannerWrapper secondaryScannerWrapperMock = mock(AsyncResultScannerWrapper.class);
+
+    final ResultScanner mirroringScanner =
+        new MirroringResultScanner(
+            new Scan(), primaryScannerMock, secondaryScannerWrapperMock, continuationFactoryMock);
+
+    doThrow(new RuntimeException("first")).when(primaryScannerMock).close();
+    doThrow(new RuntimeException("second")).when(secondaryScannerWrapperMock).close();
+
+    RuntimeException thrown =
+        assertThrows(
+            RuntimeException.class,
+            new ThrowingRunnable() {
+              @Override
+              public void run() {
+                mirroringScanner.close();
+              }
+            });
+
+    verify(primaryScannerMock, times(1)).close();
+    verify(secondaryScannerWrapperMock, times(1)).close();
+    assertThat(thrown).hasMessageThat().contains("first");
+    assertThat(thrown.getSuppressed()).hasLength(1);
+    assertThat(thrown.getSuppressed()[0]).hasMessageThat().contains("second");
+  }
+}


### PR DESCRIPTION
The implementation is straight-forward - create an asynchronous wrapper based on the underlying asynchronous wrapper and mimic the implementation of e.g. `MirroringTable::get`.

This implementation suffers from two problems:
* the verifications are "fire and forget", which means that closing the underlying client may yield errors
* the `asyncNext()` calls may get reordered, rendering the verification invalid.

Both of those problems will be fixed in future PRs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unoperate/java-bigtable-hbase-1/45)
<!-- Reviewable:end -->
