### PR TITLE
feat: defer closing underlying Connections until all operations finish

### DIFF
--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/asyncwrappers/AsyncResultScannerWrapper.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/asyncwrappers/AsyncResultScannerWrapper.java
@@ -17,8 +17,11 @@ package com.google.cloud.bigtable.mirroring.hbase1_x.asyncwrappers;
 
 import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.mirroring.hbase1_x.MirroringResultScanner;
+import com.google.cloud.bigtable.mirroring.hbase1_x.utils.ListenableCloseable;
+import com.google.cloud.bigtable.mirroring.hbase1_x.utils.ListenableReferenceCounter;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
 import java.io.IOException;
 import java.util.concurrent.Callable;
 import org.apache.hadoop.hbase.client.Result;
@@ -31,21 +34,34 @@ import org.apache.hadoop.hbase.client.Table;
  * ResultScanner into AsyncResultScannerWrapper to enable async operations on scanners.
  */
 @InternalApi("For internal usage only")
-public class AsyncResultScannerWrapper {
+public class AsyncResultScannerWrapper implements ListenableCloseable {
   private final Table table;
   private ResultScanner scanner;
   private ListeningExecutorService executorService;
+  /**
+   * We are counting references to this object to be able to call {@link ResultScanner#close()} on
+   * underlying scanner in a predictable way. The reference count is increased before submitting
+   * each asynchronous task, and decreased after it finishes. Moreover, this object holds an
+   * implicit self-reference, which in released in {@link #asyncClose()}.
+   *
+   * <p>In this way we are able to call ResultScanner#close() only if all scheduled tasks have
+   * finished and #asyncClose() was called.
+   */
+  private ListenableReferenceCounter pendingOperationsReferenceCounter;
+
+  private ListenableFuture<Void> onClosedFuture;
 
   public AsyncResultScannerWrapper(
       Table table, ResultScanner scanner, ListeningExecutorService executorService) {
     super();
     this.table = table;
     this.scanner = scanner;
+    this.pendingOperationsReferenceCounter = new ListenableReferenceCounter();
     this.executorService = executorService;
   }
 
   public ListenableFuture<Result> next() {
-    return this.executorService.submit(
+    return submitTask(
         new Callable<Result>() {
           @Override
           public Result call() throws IOException {
@@ -59,7 +75,7 @@ public class AsyncResultScannerWrapper {
   }
 
   public ListenableFuture<Result[]> next(final int nbRows) {
-    return this.executorService.submit(
+    return submitTask(
         new Callable<Result[]>() {
           @Override
           public Result[] call() throws Exception {
@@ -73,7 +89,7 @@ public class AsyncResultScannerWrapper {
   }
 
   public ListenableFuture<Boolean> renewLease() {
-    return this.executorService.submit(
+    return submitTask(
         new Callable<Boolean>() {
           @Override
           public Boolean call() {
@@ -86,18 +102,36 @@ public class AsyncResultScannerWrapper {
         });
   }
 
-  public void close() {
-    // TODO(mwalkiewicz): There is a race condition here, we should wait until all scheduled
-    // operations are finished before closing the scanner.
-    this.executorService.submit(
-        new Callable<Void>() {
+  public synchronized ListenableFuture<Void> asyncClose() {
+    if (this.onClosedFuture != null) {
+      return this.onClosedFuture;
+    }
+
+    this.pendingOperationsReferenceCounter.decrementReferenceCount();
+    this.onClosedFuture = this.pendingOperationsReferenceCounter.getOnLastReferenceClosed();
+    this.onClosedFuture.addListener(
+        new Runnable() {
           @Override
-          public Void call() {
+          public void run() {
             synchronized (table) {
               scanner.close();
-              return null;
             }
           }
-        });
+        },
+        MoreExecutors.directExecutor());
+    return this.onClosedFuture;
+  }
+
+  public <T> ListenableFuture<T> submitTask(Callable<T> task) {
+    ListenableFuture<T> future = this.executorService.submit(task);
+    this.pendingOperationsReferenceCounter.holdReferenceUntilCompletion(future);
+    return future;
+  }
+
+  @Override
+  public void addOnCloseListener(Runnable listener) {
+    this.pendingOperationsReferenceCounter
+        .getOnLastReferenceClosed()
+        .addListener(listener, MoreExecutors.directExecutor());
   }
 }

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/ListenableCloseable.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/ListenableCloseable.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.mirroring.hbase1_x.utils;
+
+/**
+ * Objects that can run registered listeners after they are closed. Facilitates reference counting
+ * using {@link ListenableReferenceCounter}, objects of classes implementing this interface can be
+ * used in {@link ListenableReferenceCounter#holdReferenceUntilClosing(ListenableCloseable)}, the
+ * reference is decreased after the referenced object is closed.
+ */
+public interface ListenableCloseable {
+  void addOnCloseListener(Runnable listener);
+}

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/ListenableReferenceCounter.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/ListenableReferenceCounter.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.mirroring.hbase1_x.utils;
+
+import com.google.api.core.InternalApi;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.SettableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Atomic Reference Counter that resolves internal future when all references were released.
+ * Interested parties can obtain the future using {@link
+ * ListenableReferenceCounter#getOnLastReferenceClosed()} and register listeners using {@link
+ * ListenableFuture#addListener(Runnable, Executor)}.
+ *
+ * <p>Used to count references to tables and scanners used asynchronously in order to prevent
+ * closing these resources while they have some scheduled or ongoing asynchronous operations.
+ */
+@InternalApi
+public class ListenableReferenceCounter {
+  private AtomicInteger referenceCount;
+  private SettableFuture<Void> onLastReferenceClosed;
+
+  public ListenableReferenceCounter() {
+    this.referenceCount = new AtomicInteger(1);
+    this.onLastReferenceClosed = SettableFuture.create();
+  }
+
+  public void incrementReferenceCount() {
+    this.referenceCount.incrementAndGet();
+  }
+
+  public void decrementReferenceCount() {
+    if (this.referenceCount.decrementAndGet() == 0) {
+      this.onLastReferenceClosed.set(null);
+    }
+  }
+
+  public ListenableFuture<Void> getOnLastReferenceClosed() {
+    return this.onLastReferenceClosed;
+  }
+
+  /** Increments the reference counter and decrements it after the future is resolved. */
+  public void holdReferenceUntilCompletion(ListenableFuture<?> future) {
+    this.incrementReferenceCount();
+    future.addListener(
+        new Runnable() {
+          @Override
+          public void run() {
+            ListenableReferenceCounter.this.decrementReferenceCount();
+          }
+        },
+        MoreExecutors.directExecutor());
+  }
+
+  /** Increments the reference counter and decrements it after the provided object is closed. */
+  public void holdReferenceUntilClosing(ListenableCloseable listenableCloseable) {
+    this.incrementReferenceCount();
+    listenableCloseable.addOnCloseListener(
+        new Runnable() {
+          @Override
+          public void run() {
+            ListenableReferenceCounter.this.decrementReferenceCount();
+          }
+        });
+  }
+}

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase1_x/asyncwrappers/TestAsyncResultScannerWrapper.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase1_x/asyncwrappers/TestAsyncResultScannerWrapper.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.mirroring.hbase1_x.asyncwrappers;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.SettableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.apache.hadoop.hbase.client.ResultScanner;
+import org.apache.hadoop.hbase.client.Table;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TestAsyncResultScannerWrapper {
+  @Test
+  public void testListenersAreCalledOnClose()
+      throws InterruptedException, ExecutionException, TimeoutException {
+    Table table = mock(Table.class);
+    ResultScanner resultScanner = mock(ResultScanner.class);
+    AsyncResultScannerWrapper asyncResultScannerWrapper =
+        new AsyncResultScannerWrapper(
+            table,
+            resultScanner,
+            MoreExecutors.listeningDecorator(MoreExecutors.newDirectExecutorService()));
+    final SettableFuture<Void> listenerFuture = SettableFuture.create();
+    asyncResultScannerWrapper.addOnCloseListener(
+        new Runnable() {
+          @Override
+          public void run() {
+            listenerFuture.set(null);
+          }
+        });
+    asyncResultScannerWrapper.asyncClose().get(3, TimeUnit.SECONDS);
+    assertThat(listenerFuture.get(3, TimeUnit.SECONDS)).isNull();
+  }
+
+  @Test
+  public void testAsyncResultScannerWrapperClosedTwiceClosesScannerOnce()
+      throws InterruptedException, ExecutionException, TimeoutException {
+    Table table = mock(Table.class);
+    ResultScanner resultScanner = mock(ResultScanner.class);
+    AsyncResultScannerWrapper asyncResultScannerWrapper =
+        new AsyncResultScannerWrapper(
+            table,
+            resultScanner,
+            MoreExecutors.listeningDecorator(MoreExecutors.newDirectExecutorService()));
+    asyncResultScannerWrapper.asyncClose().get(3, TimeUnit.SECONDS);
+    asyncResultScannerWrapper.asyncClose().get(3, TimeUnit.SECONDS);
+    verify(resultScanner, times(1)).close();
+  }
+}

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase1_x/asyncwrappers/TestAsyncTableWrapper.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase1_x/asyncwrappers/TestAsyncTableWrapper.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.mirroring.hbase1_x.asyncwrappers;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.google.common.util.concurrent.ListeningExecutorService;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.apache.hadoop.hbase.client.Table;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TestAsyncTableWrapper {
+
+  @Test
+  public void testMultipleCloseCallsCloseOnTableOnlyOnce()
+      throws InterruptedException, ExecutionException, TimeoutException, IOException {
+    Table table = mock(Table.class);
+    AsyncTableWrapper asyncTableWrapper =
+        new AsyncTableWrapper(table, mock(ListeningExecutorService.class));
+    asyncTableWrapper.asyncClose().get(3, TimeUnit.SECONDS);
+    asyncTableWrapper.asyncClose().get(3, TimeUnit.SECONDS);
+    verify(table, times(1)).close();
+  }
+}

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/TestListenableReferenceCounter.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/TestListenableReferenceCounter.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.mirroring.hbase1_x.utils;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.SettableFuture;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TestListenableReferenceCounter {
+  @Test
+  public void testFutureIsResolvedWhenCounterReachesZero() {
+    Runnable runnable = mock(Runnable.class);
+
+    ListenableReferenceCounter listenableReferenceCounter = new ListenableReferenceCounter();
+    listenableReferenceCounter
+        .getOnLastReferenceClosed()
+        .addListener(runnable, MoreExecutors.directExecutor());
+
+    verify(runnable, never()).run();
+    listenableReferenceCounter.incrementReferenceCount(); // 2
+
+    verify(runnable, never()).run();
+    listenableReferenceCounter.decrementReferenceCount(); // 1
+
+    verify(runnable, never()).run();
+    listenableReferenceCounter.decrementReferenceCount(); // 0
+    verify(runnable, times(1)).run();
+  }
+
+  @Test
+  public void testCounterIsDecrementedWhenReferenceIsDone() {
+    ListenableReferenceCounter listenableReferenceCounter = spy(new ListenableReferenceCounter());
+    SettableFuture<Void> future = SettableFuture.create();
+    verify(listenableReferenceCounter, never()).incrementReferenceCount();
+    listenableReferenceCounter.holdReferenceUntilCompletion(future);
+    verify(listenableReferenceCounter, times(1)).incrementReferenceCount();
+    verify(listenableReferenceCounter, never()).decrementReferenceCount();
+    future.set(null);
+    verify(listenableReferenceCounter, times(1)).incrementReferenceCount();
+    verify(listenableReferenceCounter, times(1)).decrementReferenceCount();
+  }
+
+  @Test
+  public void testCounterIsDecrementedWhenReferenceThrowsException() {
+    ListenableReferenceCounter listenableReferenceCounter = spy(new ListenableReferenceCounter());
+    SettableFuture<Void> future = SettableFuture.create();
+    verify(listenableReferenceCounter, never()).incrementReferenceCount();
+    listenableReferenceCounter.holdReferenceUntilCompletion(future);
+    verify(listenableReferenceCounter, times(1)).incrementReferenceCount();
+    verify(listenableReferenceCounter, never()).decrementReferenceCount();
+    future.setException(new Exception("expected"));
+    verify(listenableReferenceCounter, times(1)).incrementReferenceCount();
+    verify(listenableReferenceCounter, times(1)).decrementReferenceCount();
+  }
+}


### PR DESCRIPTION
Before this PR, closing a `MirroringTable` or a `MirroringConnection` closed the underlying tables or connections. This resulted in asynchronous operations failing.

This PR defers closing the underlying connections until after the last operation completes. This is achieved by ref counters. Objects holding these ref counters increase the count upon starting an operation and decrease upon it finishing. The object hold a self-reference to prevent self-destruction when there are no operations. A close operation is implemented as removing the self-reference and (asynchronously) waiting until there are no more references.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unoperate/java-bigtable-hbase-1/46)
<!-- Reviewable:end -->
