### PR TITLE
feat: implement MirroringAsyncTable#getScanner()

### DIFF
--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/MirroringResultScanner.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/MirroringResultScanner.java
@@ -18,7 +18,6 @@ package com.google.cloud.bigtable.mirroring.hbase1_x;
 import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.mirroring.hbase1_x.asyncwrappers.AsyncResultScannerWrapper;
 import com.google.cloud.bigtable.mirroring.hbase1_x.asyncwrappers.AsyncResultScannerWrapper.ScannerRequestContext;
-import com.google.cloud.bigtable.mirroring.hbase1_x.asyncwrappers.AsyncTableWrapper;
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.AccumulatedExceptions;
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.CallableThrowingIOException;
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.ListenableCloseable;
@@ -75,15 +74,14 @@ public class MirroringResultScanner extends AbstractClientScanner implements Lis
   public MirroringResultScanner(
       Scan originalScan,
       ResultScanner primaryResultScanner,
-      AsyncTableWrapper secondaryTableWrapper,
+      AsyncResultScannerWrapper secondaryResultScannerWrapper,
       VerificationContinuationFactory verificationContinuationFactory,
       FlowController flowController,
       MirroringTracer mirroringTracer,
-      boolean isVerificationEnabled)
-      throws IOException {
+      boolean isVerificationEnabled) {
     this.originalScan = originalScan;
     this.primaryResultScanner = primaryResultScanner;
-    this.secondaryResultScannerWrapper = secondaryTableWrapper.getScanner(originalScan);
+    this.secondaryResultScannerWrapper = secondaryResultScannerWrapper;
     this.verificationContinuationFactory = verificationContinuationFactory;
     this.listenableReferenceCounter = new ListenableReferenceCounter();
     this.flowController = flowController;

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/MirroringTable.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/MirroringTable.java
@@ -327,7 +327,7 @@ public class MirroringTable implements Table, ListenableCloseable {
           new MirroringResultScanner(
               scan,
               this.primaryTable.getScanner(scan),
-              this.secondaryAsyncWrapper,
+              this.secondaryAsyncWrapper.getScanner(scan),
               this.verificationContinuationFactory,
               this.flowController,
               this.mirroringTracer,

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase1_x/asyncwrappers/TestMirroringResultScanner.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase1_x/asyncwrappers/TestMirroringResultScanner.java
@@ -69,15 +69,12 @@ public class TestMirroringResultScanner {
         mock(VerificationContinuationFactory.class);
 
     AsyncResultScannerWrapper secondaryScannerWrapperMock = mock(AsyncResultScannerWrapper.class);
-    AsyncTableWrapper secondaryAsyncTableWrapperMock = mock(AsyncTableWrapper.class);
-    when(secondaryAsyncTableWrapperMock.getScanner(any(Scan.class)))
-        .thenReturn(secondaryScannerWrapperMock);
 
     final ResultScanner mirroringScanner =
         new MirroringResultScanner(
             new Scan(),
             primaryScannerMock,
-            secondaryAsyncTableWrapperMock,
+            secondaryScannerWrapperMock,
             continuationFactoryMock,
             flowController,
             new MirroringTracer(),
@@ -108,15 +105,12 @@ public class TestMirroringResultScanner {
         mock(VerificationContinuationFactory.class);
 
     AsyncResultScannerWrapper secondaryScannerWrapperMock = mock(AsyncResultScannerWrapper.class);
-    AsyncTableWrapper secondaryAsyncTableWrapperMock = mock(AsyncTableWrapper.class);
-    when(secondaryAsyncTableWrapperMock.getScanner(any(Scan.class)))
-        .thenReturn(secondaryScannerWrapperMock);
 
     final ResultScanner mirroringScanner =
         new MirroringResultScanner(
             new Scan(),
             primaryScannerMock,
-            secondaryAsyncTableWrapperMock,
+            secondaryScannerWrapperMock,
             continuationFactoryMock,
             flowController,
             new MirroringTracer(),
@@ -147,15 +141,12 @@ public class TestMirroringResultScanner {
         mock(VerificationContinuationFactory.class);
 
     AsyncResultScannerWrapper secondaryScannerWrapperMock = mock(AsyncResultScannerWrapper.class);
-    AsyncTableWrapper secondaryAsyncTableWrapperMock = mock(AsyncTableWrapper.class);
-    when(secondaryAsyncTableWrapperMock.getScanner(any(Scan.class)))
-        .thenReturn(secondaryScannerWrapperMock);
 
     final ResultScanner mirroringScanner =
         new MirroringResultScanner(
             new Scan(),
             primaryScannerMock,
-            secondaryAsyncTableWrapperMock,
+            secondaryScannerWrapperMock,
             continuationFactoryMock,
             flowController,
             new MirroringTracer(),
@@ -192,15 +183,11 @@ public class TestMirroringResultScanner {
     closedFuture.set(null);
     when(secondaryScannerWrapperMock.asyncClose()).thenReturn(closedFuture);
 
-    AsyncTableWrapper secondaryAsyncTableWrapperMock = mock(AsyncTableWrapper.class);
-    when(secondaryAsyncTableWrapperMock.getScanner(any(Scan.class)))
-        .thenReturn(secondaryScannerWrapperMock);
-
     final ResultScanner mirroringScanner =
         new MirroringResultScanner(
             new Scan(),
             primaryScannerMock,
-            secondaryAsyncTableWrapperMock,
+            secondaryScannerWrapperMock,
             continuationFactoryMock,
             flowController,
             new MirroringTracer(),

--- a/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase2_x/MirroringAsyncConnection.java
+++ b/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase2_x/MirroringAsyncConnection.java
@@ -29,6 +29,7 @@ import java.io.InterruptedIOException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiFunction;
@@ -60,6 +61,7 @@ public class MirroringAsyncConnection implements AsyncConnection {
   private final MirroringTracer mirroringTracer;
   private final AtomicBoolean closed = new AtomicBoolean(false);
   private final ReadSampler readSampler;
+  private final ExecutorService executorService;
 
   /**
    * The constructor called from {@link
@@ -117,6 +119,7 @@ public class MirroringAsyncConnection implements AsyncConnection {
         new SecondaryWriteErrorConsumerWithMetrics(this.mirroringTracer, writeErrorConsumer);
 
     this.readSampler = new ReadSampler(this.configuration.mirroringOptions.readSamplingRate);
+    this.executorService = Executors.newCachedThreadPool();
   }
 
   @Override
@@ -225,7 +228,8 @@ public class MirroringAsyncConnection implements AsyncConnection {
           secondaryWriteErrorConsumer,
           mirroringTracer,
           readSampler,
-          referenceCounter);
+          referenceCounter,
+          executorService);
     }
 
     private AsyncTableBuilder<C> setTimeParameter(

--- a/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase2_x/TestMirroringAsyncTableInputModification.java
+++ b/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase2_x/TestMirroringAsyncTableInputModification.java
@@ -40,6 +40,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
@@ -70,6 +71,7 @@ public class TestMirroringAsyncTableInputModification {
   @Mock FlowController flowController;
   @Mock SecondaryWriteErrorConsumerWithMetrics secondaryWriteErrorConsumer;
   @Mock ListenableReferenceCounter referenceCounter;
+  @Mock ExecutorService executorService;
 
   MirroringAsyncTable<ScanResultConsumerBase> mirroringTable;
   CompletableFuture<Void> letPrimaryThroughFuture;
@@ -89,7 +91,8 @@ public class TestMirroringAsyncTableInputModification {
                 secondaryWriteErrorConsumer,
                 new MirroringTracer(),
                 new ReadSampler(100),
-                referenceCounter));
+                referenceCounter,
+                executorService));
 
     secondaryOperationAllowedFuture = SettableFuture.create();
     blockMethodCall(secondaryTable, secondaryOperationAllowedFuture).exists(anyList());

--- a/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase2_x/TestVerificationSampling.java
+++ b/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase2_x/TestVerificationSampling.java
@@ -92,7 +92,8 @@ public class TestVerificationSampling {
                 secondaryWriteErrorConsumer,
                 new MirroringTracer(),
                 readSampler,
-                referenceCounter));
+                referenceCounter,
+                executorServiceRule.executorService));
   }
 
   public <T, R> T mockWithCompleteFuture(T table, R result) {
@@ -209,13 +210,13 @@ public class TestVerificationSampling {
     verify(secondaryTable, times(1)).batch(ImmutableList.of(put));
   }
 
-  @Test(expected = UnsupportedOperationException.class) // Disable until scanner is implemented
+  @Test
   public void isResultScannerSampled() {
     mirroringTable.getScanner(new Scan());
     verify(readSampler, times(1)).shouldNextReadOperationBeSampled();
   }
 
-  @Test(expected = UnsupportedOperationException.class) // Disable until scanner is implemented
+  @Test
   public void testResultScannerWithSampling() throws IOException {
     ResultScanner primaryScanner = mock(ResultScanner.class);
     ResultScanner secondaryScanner = mock(ResultScanner.class);
@@ -231,7 +232,7 @@ public class TestVerificationSampling {
     verify(secondaryScanner, times(1)).next();
   }
 
-  @Test(expected = UnsupportedOperationException.class) // Disable until scanner is implemented
+  @Test
   public void testResultScannerWithoutSampling() throws IOException {
     ResultScanner primaryScanner = mock(ResultScanner.class);
     ResultScanner secondaryScanner = mock(ResultScanner.class);


### PR DESCRIPTION
Reuse MirroringResultScanner from 1.x client in 2.x client.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unoperate/java-bigtable-hbase-1/58)
<!-- Reviewable:end -->
