### PR TITLE
feat: MirroringAsyncBufferedMutator

### DIFF
--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/mirroringmetrics/MirroringSpanConstants.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/mirroringmetrics/MirroringSpanConstants.java
@@ -92,7 +92,8 @@ public class MirroringSpanConstants {
     BUFFERED_MUTATOR_MUTATE_LIST("mutateList"),
     MIRRORING_CONNECTION_CLOSE("MirroringConnection.close"),
     MIRRORING_CONNECTION_ABORT("MirroringConnection.abort"),
-    BUFFERED_MUTATOR_CLOSE("BufferedMutator.close");
+    BUFFERED_MUTATOR_CLOSE("BufferedMutator.close"),
+    MIRRORING_BUFFERED_MUTATOR_CLOSE("MirroringBufferedMutator.close");
 
     private final String string;
     private final TagValue tagValue;

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/mirroringmetrics/MirroringSpanConstants.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/mirroringmetrics/MirroringSpanConstants.java
@@ -92,8 +92,7 @@ public class MirroringSpanConstants {
     BUFFERED_MUTATOR_MUTATE_LIST("mutateList"),
     MIRRORING_CONNECTION_CLOSE("MirroringConnection.close"),
     MIRRORING_CONNECTION_ABORT("MirroringConnection.abort"),
-    BUFFERED_MUTATOR_CLOSE("BufferedMutator.close"),
-    MIRRORING_BUFFERED_MUTATOR_CLOSE("MirroringBufferedMutator.close");
+    BUFFERED_MUTATOR_CLOSE("BufferedMutator.close");
 
     private final String string;
     private final TagValue tagValue;

--- a/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase2_x/MirroringAsyncBufferedMutator.java
+++ b/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase2_x/MirroringAsyncBufferedMutator.java
@@ -21,9 +21,7 @@ import com.google.cloud.bigtable.mirroring.hbase1_x.utils.SecondaryWriteErrorCon
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.flowcontrol.FlowController;
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.flowcontrol.RequestResourcesDescription;
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.mirroringmetrics.MirroringSpanConstants;
-import com.google.cloud.bigtable.mirroring.hbase1_x.utils.mirroringmetrics.MirroringTracer;
 import com.google.cloud.bigtable.mirroring.hbase2_x.utils.futures.FutureConverter;
-import io.opencensus.common.Scope;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -43,8 +41,7 @@ public class MirroringAsyncBufferedMutator implements AsyncBufferedMutator {
   private final FlowController flowController;
   private final ListenableReferenceCounter referenceCounter;
   private final SecondaryWriteErrorConsumerWithMetrics secondaryWriteErrorConsumer;
-  private final MirroringTracer mirroringTracer;
-  private AtomicBoolean closed = new AtomicBoolean(false);
+  private final AtomicBoolean closed = new AtomicBoolean(false);
 
   public MirroringAsyncBufferedMutator(
       AsyncBufferedMutator primary,
@@ -56,7 +53,6 @@ public class MirroringAsyncBufferedMutator implements AsyncBufferedMutator {
     this.flowController = flowController;
     this.secondaryWriteErrorConsumer = secondaryWriteErrorConsumer;
     this.referenceCounter = new ListenableReferenceCounter();
-    this.mirroringTracer = new MirroringTracer();
   }
 
   @Override

--- a/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase2_x/MirroringAsyncBufferedMutator.java
+++ b/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase2_x/MirroringAsyncBufferedMutator.java
@@ -35,7 +35,7 @@ public class MirroringAsyncBufferedMutator implements AsyncBufferedMutator {
   private final AsyncBufferedMutator primary;
   private final AsyncBufferedMutator secondary;
   private final FlowController flowController;
-  private ListenableReferenceCounter referenceCounter;
+  private final ListenableReferenceCounter referenceCounter;
 
   public MirroringAsyncBufferedMutator(
       AsyncBufferedMutator primary, AsyncBufferedMutator secondary, FlowController flowController) {
@@ -77,7 +77,7 @@ public class MirroringAsyncBufferedMutator implements AsyncBufferedMutator {
                         resultFuture.complete(null);
                         secondary
                             .mutate(mutation)
-                            .thenRun(() -> referenceCounter.decrementReferenceCount())
+                            .thenRun(referenceCounter::decrementReferenceCount)
                             .exceptionally(
                                 ex -> {
                                   // TODO log secondary error

--- a/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase2_x/MirroringAsyncBufferedMutator.java
+++ b/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase2_x/MirroringAsyncBufferedMutator.java
@@ -90,7 +90,8 @@ public class MirroringAsyncBufferedMutator implements AsyncBufferedMutator {
                                 secondaryError -> {
                                   this.secondaryWriteErrorConsumer.consume(
                                       MirroringSpanConstants.HBaseOperation.BUFFERED_MUTATOR_MUTATE,
-                                      mutation);
+                                      mutation,
+                                      secondaryError);
                                   referenceCounter.decrementReferenceCount();
                                   return null;
                                 });
@@ -101,7 +102,8 @@ public class MirroringAsyncBufferedMutator implements AsyncBufferedMutator {
                         resultFuture.complete(null);
                         this.secondaryWriteErrorConsumer.consume(
                             MirroringSpanConstants.HBaseOperation.BUFFERED_MUTATOR_MUTATE,
-                            mutation);
+                            mutation,
+                            resourceReservationError);
                         return null;
                       });
             })

--- a/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase2_x/MirroringAsyncBufferedMutator.java
+++ b/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase2_x/MirroringAsyncBufferedMutator.java
@@ -136,18 +136,14 @@ public class MirroringAsyncBufferedMutator implements AsyncBufferedMutator {
 
   @Override
   public synchronized void close() {
-    try (Scope scope =
-        this.mirroringTracer.spanFactory.operationScope(
-            MirroringSpanConstants.HBaseOperation.MIRRORING_BUFFERED_MUTATOR_CLOSE)) {
-      if (this.closed.get()) {
-        return;
-      }
-      this.closed.set(true);
-      closeMirroringBufferedMutatorAndWaitForAsyncOperations();
-
-      this.primary.close();
-      this.secondary.close();
+    if (this.closed.get()) {
+      return;
     }
+    this.closed.set(true);
+    closeMirroringBufferedMutatorAndWaitForAsyncOperations();
+
+    this.primary.close();
+    this.secondary.close();
   }
 
   @Override

--- a/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase2_x/MirroringAsyncBufferedMutator.java
+++ b/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase2_x/MirroringAsyncBufferedMutator.java
@@ -83,7 +83,6 @@ public class MirroringAsyncBufferedMutator implements AsyncBufferedMutator {
     primaryCompleted
         .thenRun(
             () -> {
-              // when primary completes, request resources.
               CompletableFuture<FlowController.ResourceReservation> resourceRequested =
                   FutureConverter.toCompletable(
                       flowController.asyncRequestResource(
@@ -92,7 +91,6 @@ public class MirroringAsyncBufferedMutator implements AsyncBufferedMutator {
               resourceRequested
                   .thenRun(
                       () -> {
-                        // got resources, complete resultFuture and schedule secondary
                         resultFuture.complete(null);
                         secondary
                             .mutate(mutation)
@@ -108,7 +106,6 @@ public class MirroringAsyncBufferedMutator implements AsyncBufferedMutator {
                       })
                   .exceptionally(
                       resourceReservationError -> {
-                        // got error, complete resultFuture and handle secondary failure
                         referenceCounter.decrementReferenceCount();
                         resultFuture.complete(null);
                         this.secondaryWriteErrorConsumer.consume(
@@ -119,7 +116,6 @@ public class MirroringAsyncBufferedMutator implements AsyncBufferedMutator {
             })
         .exceptionally(
             primaryError -> {
-              // primary failed, propagate error
               referenceCounter.decrementReferenceCount();
               resultFuture.completeExceptionally(primaryError);
               return null;

--- a/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase2_x/MirroringAsyncBufferedMutator.java
+++ b/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase2_x/MirroringAsyncBufferedMutator.java
@@ -47,12 +47,12 @@ public class MirroringAsyncBufferedMutator implements AsyncBufferedMutator {
 
   @Override
   public TableName getName() {
-    return null;
+    return primary.getName();
   }
 
   @Override
   public Configuration getConfiguration() {
-    return null;
+    return primary.getConfiguration();
   }
 
   @Override

--- a/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase2_x/MirroringAsyncBufferedMutator.java
+++ b/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase2_x/MirroringAsyncBufferedMutator.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.mirroring.hbase2_x;
+
+import com.google.cloud.bigtable.mirroring.hbase1_x.utils.flowcontrol.FlowController;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.AsyncBufferedMutator;
+import org.apache.hadoop.hbase.client.Mutation;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+public class MirroringAsyncBufferedMutator implements AsyncBufferedMutator {
+
+  private final AsyncBufferedMutator primary;
+  private final AsyncBufferedMutator secondary;
+
+  public MirroringAsyncBufferedMutator(
+      AsyncBufferedMutator primary,
+      AsyncBufferedMutator secondary,
+      FlowController flowController) {
+    this.primary = primary;
+    this.secondary = secondary;
+  }
+
+  @Override
+  public TableName getName() {
+    return null;
+  }
+
+  @Override
+  public Configuration getConfiguration() {
+    return null;
+  }
+
+  @Override
+  public CompletableFuture<Void> mutate(Mutation mutation) {
+    CompletableFuture<Void> primaryCompleted = primary.mutate(mutation);
+    primaryCompleted.thenRunAsync(() -> secondary.mutate(mutation));
+
+    return primaryCompleted;
+  }
+
+  @Override
+  public List<CompletableFuture<Void>> mutate(List<? extends Mutation> list) {
+    return null;
+  }
+
+  @Override
+  public void flush() {}
+
+  @Override
+  public void close() {}
+
+  @Override
+  public long getWriteBufferSize() {
+    return 0;
+  }
+
+  @Override
+  public long getPeriodicalFlushTimeout(TimeUnit unit) {
+    return AsyncBufferedMutator.super.getPeriodicalFlushTimeout(unit);
+  }
+}

--- a/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase2_x/MirroringAsyncBufferedMutator.java
+++ b/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase2_x/MirroringAsyncBufferedMutator.java
@@ -16,7 +16,6 @@
 package com.google.cloud.bigtable.mirroring.hbase2_x;
 
 import com.google.api.core.InternalApi;
-import com.google.cloud.bigtable.mirroring.hbase1_x.utils.AccumulatedExceptions;
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.ListenableReferenceCounter;
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.SecondaryWriteErrorConsumerWithMetrics;
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.flowcontrol.FlowController;
@@ -24,17 +23,13 @@ import com.google.cloud.bigtable.mirroring.hbase1_x.utils.flowcontrol.RequestRes
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.mirroringmetrics.MirroringSpanConstants;
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.mirroringmetrics.MirroringTracer;
 import com.google.cloud.bigtable.mirroring.hbase2_x.utils.futures.FutureConverter;
-
-import java.io.IOException;
-import java.io.InterruptedIOException;
+import io.opencensus.common.Scope;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-
-import io.opencensus.common.Scope;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.AsyncBufferedMutator;
@@ -142,8 +137,8 @@ public class MirroringAsyncBufferedMutator implements AsyncBufferedMutator {
   @Override
   public synchronized void close() {
     try (Scope scope =
-                 this.mirroringTracer.spanFactory.operationScope(
-                         MirroringSpanConstants.HBaseOperation.MIRRORING_BUFFERED_MUTATOR_CLOSE)) {
+        this.mirroringTracer.spanFactory.operationScope(
+            MirroringSpanConstants.HBaseOperation.MIRRORING_BUFFERED_MUTATOR_CLOSE)) {
       if (this.closed.get()) {
         return;
       }
@@ -165,7 +160,7 @@ public class MirroringAsyncBufferedMutator implements AsyncBufferedMutator {
     return primary.getPeriodicalFlushTimeout(unit);
   }
 
-  private void closeMirroringBufferedMutatorAndWaitForAsyncOperations(){
+  private void closeMirroringBufferedMutatorAndWaitForAsyncOperations() {
     this.referenceCounter.decrementReferenceCount();
     try {
       this.referenceCounter.getOnLastReferenceClosed().get();

--- a/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase2_x/TestMirroringAsyncBufferedMutator.java
+++ b/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase2_x/TestMirroringAsyncBufferedMutator.java
@@ -55,7 +55,6 @@ public class TestMirroringAsyncBufferedMutator {
   CompletableFuture<Void> secondaryCalled;
   Put put;
 
-
   MirroringAsyncBufferedMutator mirroringMutator;
 
   @Before
@@ -72,8 +71,6 @@ public class TestMirroringAsyncBufferedMutator {
     this.primaryFuture = new CompletableFuture<>();
     this.secondaryCalled = new CompletableFuture<>();
     when(primaryMutator.mutate(put)).thenReturn(primaryFuture);
-
-
   }
 
   @Test
@@ -127,7 +124,8 @@ public class TestMirroringAsyncBufferedMutator {
     verify(secondaryMutator, times(0)).mutate(put);
     try {
       resultFuture.get();
-    } catch (InterruptedException | ExecutionException ignored) {}
+    } catch (InterruptedException | ExecutionException ignored) {
+    }
     assertThat(resultFuture.isCompletedExceptionally()).isTrue();
     assertThat(secondaryCalled.isDone()).isFalse();
   }

--- a/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase2_x/TestMirroringAsyncBufferedMutator.java
+++ b/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase2_x/TestMirroringAsyncBufferedMutator.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.mirroring.hbase2_x;
+
+import static com.google.cloud.bigtable.mirroring.hbase1_x.TestHelpers.createGet;
+import static com.google.cloud.bigtable.mirroring.hbase1_x.TestHelpers.createGets;
+import static com.google.cloud.bigtable.mirroring.hbase1_x.TestHelpers.createPut;
+import static com.google.cloud.bigtable.mirroring.hbase1_x.TestHelpers.createResult;
+import static com.google.cloud.bigtable.mirroring.hbase1_x.TestHelpers.setupFlowControllerMock;
+import static com.google.cloud.bigtable.mirroring.hbase1_x.TestHelpers.setupFlowControllerToRejectRequests;
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.bigtable.mirroring.hbase1_x.utils.SecondaryWriteErrorConsumerWithMetrics;
+import com.google.cloud.bigtable.mirroring.hbase1_x.utils.flowcontrol.FlowController;
+import com.google.cloud.bigtable.mirroring.hbase1_x.utils.mirroringmetrics.MirroringSpanConstants.HBaseOperation;
+import com.google.cloud.bigtable.mirroring.hbase1_x.utils.mirroringmetrics.MirroringTracer;
+import com.google.cloud.bigtable.mirroring.hbase1_x.verification.MismatchDetector;
+import com.google.common.primitives.Longs;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellBuilderFactory;
+import org.apache.hadoop.hbase.CellBuilderType;
+import org.apache.hadoop.hbase.client.*;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+@RunWith(JUnit4.class)
+public class TestMirroringAsyncBufferedMutator {
+    @Rule public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock AsyncBufferedMutator primaryMutator;
+    @Mock AsyncBufferedMutator secondaryMutator;
+    @Mock FlowController flowController;
+
+    MirroringAsyncBufferedMutator mirroringMutator;
+
+    @Before
+    public void setUp() {
+        setupFlowControllerMock(flowController);
+        this.mirroringMutator =
+                spy(
+                        new MirroringAsyncBufferedMutator(
+                                primaryMutator,
+                                secondaryMutator,
+                                flowController));
+    }
+
+    @Test
+    public void testResultIsCompletedOnPrimaryCompletion()
+            throws ExecutionException, InterruptedException {
+        Put put = new Put(Bytes.toBytes("rowKey"));
+        put.addColumn(Bytes.toBytes("cf1"), Bytes.toBytes("c1"), Bytes.toBytes("value"));
+
+        CompletableFuture<Void> primaryFuture = new CompletableFuture<>();
+        CompletableFuture<Void> secondaryCalled = new CompletableFuture<>();
+        when(primaryMutator.mutate(put)).thenReturn(primaryFuture);
+        when(secondaryMutator.mutate(put)).thenAnswer(invocationOnMock -> {
+            secondaryCalled.complete(null);
+            return new CompletableFuture<>();
+        });
+
+        CompletableFuture<Void> resultFuture = mirroringMutator.mutate(put);
+
+        assertThat(resultFuture.isDone()).isFalse();
+        verify(primaryMutator, times(1)).mutate(put);
+        verify(secondaryMutator, times(0)).mutate(put);
+
+        primaryFuture.complete(null);
+        resultFuture.get();
+        assertThat(resultFuture.isDone()).isTrue();
+        secondaryCalled.get();
+        verify(secondaryMutator, times(1)).mutate(put);
+    }
+
+}


### PR DESCRIPTION
Introducing MirroringAsyncBufferedMutator.

Mutate returns a future that gets completed only when the write to primary has completed and resources have been allocated for the secondary write.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unoperate/java-bigtable-hbase-1/81)
<!-- Reviewable:end -->
