### PR TITLE
feat: better mismatch detection of scan results

### DIFF
--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/MirroringConnection.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/MirroringConnection.java
@@ -67,7 +67,7 @@ public class MirroringConnection implements Connection {
   protected final SecondaryWriteErrorConsumer secondaryWriteErrorConsumer;
   protected final ReadSampler readSampler;
   private final FailedMutationLogger failedMutationLogger;
-  private final MirroringConfiguration configuration;
+  protected final MirroringConfiguration configuration;
   private final Connection primaryConnection;
   private final Connection secondaryConnection;
   private final AtomicBoolean closed = new AtomicBoolean(false);
@@ -185,7 +185,8 @@ public class MirroringConnection implements Connection {
           this.performWritesConcurrently,
           this.waitForSecondaryWrites,
           this.mirroringTracer,
-          this.referenceCounter);
+          this.referenceCounter,
+          this.configuration.mirroringOptions.maxLoggedBinaryValueLength);
     }
   }
 

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/MirroringOptions.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/MirroringOptions.java
@@ -26,6 +26,7 @@ import static com.google.cloud.bigtable.mirroring.hbase1_x.utils.MirroringConfig
 import static com.google.cloud.bigtable.mirroring.hbase1_x.utils.MirroringConfigurationHelper.MIRRORING_FLOW_CONTROLLER_STRATEGY_FACTORY_CLASS;
 import static com.google.cloud.bigtable.mirroring.hbase1_x.utils.MirroringConfigurationHelper.MIRRORING_MISMATCH_DETECTOR_FACTORY_CLASS;
 import static com.google.cloud.bigtable.mirroring.hbase1_x.utils.MirroringConfigurationHelper.MIRRORING_READ_VERIFICATION_RATE_PERCENT;
+import static com.google.cloud.bigtable.mirroring.hbase1_x.utils.MirroringConfigurationHelper.MIRRORING_SCANNER_BUFFERED_MISMATCHED_READS;
 import static com.google.cloud.bigtable.mirroring.hbase1_x.utils.MirroringConfigurationHelper.MIRRORING_SYNCHRONOUS_WRITES;
 import static com.google.cloud.bigtable.mirroring.hbase1_x.utils.MirroringConfigurationHelper.MIRRORING_WRITE_ERROR_CONSUMER_FACTORY_CLASS;
 import static com.google.cloud.bigtable.mirroring.hbase1_x.utils.MirroringConfigurationHelper.MIRRORING_WRITE_ERROR_LOG_APPENDER_FACTORY_CLASS;
@@ -89,6 +90,8 @@ public class MirroringOptions {
   public final boolean waitForSecondaryWrites;
   public final Faillog faillog;
 
+  public final int resultScannerBufferedMismatchedResults;
+
   public MirroringOptions(Configuration configuration) {
     this.mismatchDetectorFactoryClass =
         configuration.getClass(
@@ -114,16 +117,21 @@ public class MirroringOptions {
             DefaultSecondaryWriteErrorConsumer.Factory.class,
             SecondaryWriteErrorConsumer.Factory.class);
     this.readSamplingRate = configuration.getInt(MIRRORING_READ_VERIFICATION_RATE_PERCENT, 100);
-
-    this.maxLoggedBinaryValueLength =
-        configuration.getInt(MIRRORING_WRITE_ERROR_LOG_MAX_BINARY_VALUE_LENGTH, 32);
-
     Preconditions.checkArgument(this.readSamplingRate >= 0);
     Preconditions.checkArgument(this.readSamplingRate <= 100);
+
     this.performWritesConcurrently = configuration.getBoolean(MIRRORING_CONCURRENT_WRITES, false);
     this.waitForSecondaryWrites = configuration.getBoolean(MIRRORING_SYNCHRONOUS_WRITES, false);
     this.connectionTerminationTimeoutMillis =
         configuration.getLong(MIRRORING_CONNECTION_CONNECTION_TERMINATION_TIMEOUT, 60000);
+
+    this.resultScannerBufferedMismatchedResults =
+        configuration.getInt(MIRRORING_SCANNER_BUFFERED_MISMATCHED_READS, 5);
+    Preconditions.checkArgument(this.resultScannerBufferedMismatchedResults >= 0);
+
+    this.maxLoggedBinaryValueLength =
+        configuration.getInt(MIRRORING_WRITE_ERROR_LOG_MAX_BINARY_VALUE_LENGTH, 32);
+    Preconditions.checkArgument(this.maxLoggedBinaryValueLength >= 0);
 
     Preconditions.checkArgument(
         !(this.performWritesConcurrently && !this.waitForSecondaryWrites),

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/MirroringTable.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/MirroringTable.java
@@ -113,7 +113,7 @@ public class MirroringTable implements Table {
   private final Batcher batcher;
   private final AtomicBoolean closed = new AtomicBoolean(false);
   private final SettableFuture<Void> closedFuture = SettableFuture.create();
-
+  private final int resultScannerBufferedMismatchedResults;
   /**
    * @param executorService ExecutorService is used to perform operations on secondaryTable and
    *     verification tasks.
@@ -132,7 +132,8 @@ public class MirroringTable implements Table {
       boolean performWritesConcurrently,
       boolean waitForSecondaryWrites,
       MirroringTracer mirroringTracer,
-      ReferenceCounter parentReferenceCounter) {
+      ReferenceCounter parentReferenceCounter,
+      int resultScannerBufferedMismatchedResults) {
     this.primaryTable = primaryTable;
     this.verificationContinuationFactory = new VerificationContinuationFactory(mismatchDetector);
     this.readSampler = readSampler;
@@ -159,6 +160,7 @@ public class MirroringTable implements Table {
             waitForSecondaryWrites,
             performWritesConcurrently,
             this.mirroringTracer);
+    this.resultScannerBufferedMismatchedResults = resultScannerBufferedMismatchedResults;
   }
 
   @Override
@@ -269,7 +271,8 @@ public class MirroringTable implements Table {
               this.mirroringTracer,
               this.readSampler.shouldNextReadOperationBeSampled(),
               this.requestScheduler,
-              this.referenceCounter);
+              this.referenceCounter,
+              this.resultScannerBufferedMismatchedResults);
       return scanner;
     }
   }

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/MirroringConfigurationHelper.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/MirroringConfigurationHelper.java
@@ -17,6 +17,7 @@ package com.google.cloud.bigtable.mirroring.hbase1_x.utils;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.google.cloud.bigtable.mirroring.hbase1_x.MirroringResultScanner;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -184,7 +185,7 @@ public class MirroringConfigurationHelper {
   public static final String MIRRORING_FAILLOG_DROP_ON_OVERFLOW_KEY =
       "google.bigtable.mirroring.write-error-log.appender.drop-on-overflow";
 
-  /*
+  /**
    * Number of milliseconds that {@link
    * com.google.cloud.bigtable.mirroring.hbase1_x.MirroringConnection} should wait synchronously for
    * pending operations before terminating connection with secondary database.
@@ -197,6 +198,16 @@ public class MirroringConfigurationHelper {
    */
   public static final String MIRRORING_CONNECTION_CONNECTION_TERMINATION_TIMEOUT =
       "google.bigtable.mirroring.connection.termination-timeout";
+
+  /**
+   * Number of previous unmatched results that {@link MirroringResultScanner} should check before
+   * declaring scan's results erroneous.
+   *
+   * <p>If not set uses default value of 5. Matching to one of buffered results removes earlier
+   * entries from the buffer.
+   */
+  public static final String MIRRORING_SCANNER_BUFFERED_MISMATCHED_READS =
+      "google.bigtable.mirroring.result-scanner.buffered-mismatched-reads";
 
   public static void fillConnectionConfigWithClassImplementation(
       Configuration connectionConfig,

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/verification/MismatchDetector.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/verification/MismatchDetector.java
@@ -43,13 +43,15 @@ public interface MismatchDetector {
 
   void get(List<Get> request, Throwable throwable);
 
-  void scannerNext(Scan request, int entriesAlreadyRead, Result primary, Result secondary);
+  void scannerNext(
+      Scan request, ScannerResultVerifier mismatches, Result primary, Result secondary);
 
-  void scannerNext(Scan request, int entriesAlreadyRead, Throwable throwable);
+  void scannerNext(Scan request, Throwable throwable);
 
-  void scannerNext(Scan request, int entriesAlreadyRead, Result[] primary, Result[] secondary);
+  void scannerNext(
+      Scan request, ScannerResultVerifier mismatches, Result[] primary, Result[] secondary);
 
-  void scannerNext(Scan request, int entriesAlreadyRead, int entriesRequested, Throwable throwable);
+  void scannerNext(Scan request, int entriesRequested, Throwable throwable);
 
   void batch(List<Get> request, Result[] primary, Result[] secondary);
 
@@ -58,5 +60,13 @@ public interface MismatchDetector {
   interface Factory {
     MismatchDetector create(MirroringTracer mirroringTracer, Integer maxLoggedBinaryValueLength)
         throws Throwable;
+  }
+
+  ScannerResultVerifier createScannerResultVerifier(Scan request, int maxBufferedResults);
+
+  interface ScannerResultVerifier {
+    void verify(Result[] primary, Result[] secondary);
+
+    void flush();
   }
 }

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/verification/MismatchDetector.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/verification/MismatchDetector.java
@@ -64,6 +64,10 @@ public interface MismatchDetector {
 
   ScannerResultVerifier createScannerResultVerifier(Scan request, int maxBufferedResults);
 
+  /**
+   * Interface of helper classes used to detect non-trivial mismatches in scan operations, such as
+   * elements missing in one of the databases.
+   */
   interface ScannerResultVerifier {
     void verify(Result[] primary, Result[] secondary);
 

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase1_x/TestMirroringMetrics.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase1_x/TestMirroringMetrics.java
@@ -119,7 +119,8 @@ public class TestMirroringMetrics {
                 false,
                 false,
                 tracer,
-                mock(ReferenceCounter.class)));
+                mock(ReferenceCounter.class),
+                10));
   }
 
   @Test

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase1_x/TestMirroringTable.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase1_x/TestMirroringTable.java
@@ -44,14 +44,19 @@ import com.google.cloud.bigtable.mirroring.hbase1_x.utils.ReadSampler;
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.SecondaryWriteErrorConsumerWithMetrics;
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.flowcontrol.FlowController;
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.flowcontrol.RequestResourcesDescription;
+import com.google.cloud.bigtable.mirroring.hbase1_x.utils.mirroringmetrics.MirroringMetricsRecorder;
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.mirroringmetrics.MirroringSpanConstants.HBaseOperation;
+import com.google.cloud.bigtable.mirroring.hbase1_x.utils.mirroringmetrics.MirroringSpanFactory;
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.mirroringmetrics.MirroringTracer;
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.referencecounting.ReferenceCounter;
+import com.google.cloud.bigtable.mirroring.hbase1_x.verification.DefaultMismatchDetector;
 import com.google.cloud.bigtable.mirroring.hbase1_x.verification.MismatchDetector;
+import com.google.cloud.bigtable.mirroring.hbase1_x.verification.MismatchDetector.ScannerResultVerifier;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Longs;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
+import io.opencensus.trace.Tracing;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -105,16 +110,23 @@ public class TestMirroringTable {
 
   @Mock Table primaryTable;
   @Mock Table secondaryTable;
-  @Mock MismatchDetector mismatchDetector;
   @Mock FlowController flowController;
   @Mock SecondaryWriteErrorConsumerWithMetrics secondaryWriteErrorConsumer;
   @Mock ReferenceCounter referenceCounter;
+  @Mock MirroringMetricsRecorder mirroringMetricsRecorder;
 
+  MismatchDetector mismatchDetector;
   MirroringTable mirroringTable;
+  MirroringTracer mirroringTracer;
 
   @Before
   public void setUp() {
     setupFlowControllerMock(flowController);
+    this.mirroringTracer =
+        new MirroringTracer(
+            new MirroringSpanFactory(Tracing.getTracer(), mirroringMetricsRecorder),
+            mirroringMetricsRecorder);
+    this.mismatchDetector = spy(new DefaultMismatchDetector(this.mirroringTracer, 100));
     this.mirroringTable =
         spy(
             new MirroringTable(
@@ -127,8 +139,9 @@ public class TestMirroringTable {
                 new ReadSampler(100),
                 false,
                 false,
-                new MirroringTracer(),
-                this.referenceCounter));
+                this.mirroringTracer,
+                this.referenceCounter,
+                1000));
   }
 
   private void waitForMirroringScanner(ResultScanner mirroringScanner)
@@ -325,9 +338,15 @@ public class TestMirroringTable {
     waitForMirroringScanner(mirroringScanner);
     executorServiceRule.waitForExecutor();
 
-    verify(mismatchDetector, times(1)).scannerNext(scan, 0, expected1, expected1);
-    verify(mismatchDetector, times(1)).scannerNext(scan, 1, expected2, expected2);
-    verify(mismatchDetector, times(1)).scannerNext(scan, 2, (Result) null, null);
+    verify(mismatchDetector, times(1))
+        .scannerNext(eq(scan), any(ScannerResultVerifier.class), eq(expected1), eq(expected1));
+    verify(mismatchDetector, times(1))
+        .scannerNext(eq(scan), any(ScannerResultVerifier.class), eq(expected2), eq(expected2));
+    verify(mismatchDetector, times(1))
+        .scannerNext(
+            eq(scan), any(ScannerResultVerifier.class), eq((Result) null), eq((Result) null));
+    verify(mismatchDetector, times(3))
+        .scannerNext(eq(scan), any(ScannerResultVerifier.class), (Result) any(), (Result) any());
   }
 
   @Test
@@ -362,11 +381,14 @@ public class TestMirroringTable {
     waitForMirroringScanner(mirroringScanner);
     executorServiceRule.waitForExecutor();
 
-    verify(mismatchDetector, times(1)).scannerNext(scan, 0, expected1, expected1);
-    verify(mismatchDetector, times(1)).scannerNext(scan, 1, expectedException);
-    verify(mismatchDetector, times(1)).scannerNext(scan, 2, (Result) null, null);
+    verify(mismatchDetector, times(1))
+        .scannerNext(eq(scan), any(ScannerResultVerifier.class), eq(expected1), eq(expected1));
+    verify(mismatchDetector, times(1)).scannerNext(scan, expectedException);
+    verify(mismatchDetector, times(1))
+        .scannerNext(
+            eq(scan), any(ScannerResultVerifier.class), eq((Result) null), eq((Result) null));
     verify(mismatchDetector, times(2))
-        .scannerNext(eq(scan), anyInt(), (Result) any(), (Result) any());
+        .scannerNext(eq(scan), any(ScannerResultVerifier.class), (Result) any(), (Result) any());
   }
 
   @Test
@@ -393,7 +415,8 @@ public class TestMirroringTable {
     waitForMirroringScanner(mirroringScanner);
     executorServiceRule.waitForExecutor();
 
-    verify(mismatchDetector, times(1)).scannerNext(scan, 0, expected, expected);
+    verify(mismatchDetector, times(1))
+        .scannerNext(eq(scan), any(ScannerResultVerifier.class), eq(expected), eq(expected));
   }
 
   @Test
@@ -421,7 +444,7 @@ public class TestMirroringTable {
     waitForMirroringScanner(mirroringScanner);
     executorServiceRule.waitForExecutor();
 
-    verify(mismatchDetector, times(1)).scannerNext(scan, 0, 2, expectedException);
+    verify(mismatchDetector, times(1)).scannerNext(scan, 2, expectedException);
   }
 
   @Test
@@ -1246,9 +1269,9 @@ public class TestMirroringTable {
                 new ReadSampler(100),
                 performWritesConcurrently,
                 waitForSecondaryWrites,
-                new MirroringTracer(),
-                this.referenceCounter));
-
+                this.mirroringTracer,
+                this.referenceCounter,
+                10));
     Put put1 = createPut("r1", "f1", "q1", "v1");
 
     // Both batches should be called even if first one fails.
@@ -1335,8 +1358,9 @@ public class TestMirroringTable {
                 new ReadSampler(100),
                 performWritesConcurrently,
                 waitForSecondaryWrites,
-                new MirroringTracer(),
-                this.referenceCounter));
+                this.mirroringTracer,
+                this.referenceCounter,
+                10));
   }
 
   private void checkBatchCalledSequentially(List<? extends Row> requests)
@@ -1466,8 +1490,9 @@ public class TestMirroringTable {
                 new ReadSampler(100),
                 performWritesConcurrently,
                 waitForSecondaryWrites,
-                new MirroringTracer(),
-                this.referenceCounter));
+                this.mirroringTracer,
+                this.referenceCounter,
+                10));
 
     Put put = createPut("test1", "f1", "q1", "v1");
     mockBatch(primaryTable, secondaryTable);
@@ -1522,5 +1547,207 @@ public class TestMirroringTable {
 
     verify(primaryTable, never()).batch(ArgumentMatchers.<Row>anyList(), any(Object[].class));
     verify(secondaryTable, never()).batch(ArgumentMatchers.<Row>anyList(), any(Object[].class));
+  }
+
+  @Test
+  public void testUnmatchedScannerResultQueuesAreFlushedWhenResultScannerIsClosed()
+      throws IOException, InterruptedException, ExecutionException, TimeoutException {
+    ScannerResultVerifier verifier =
+        spy(mismatchDetector.createScannerResultVerifier(new Scan(), 100));
+    when(mismatchDetector.createScannerResultVerifier(any(Scan.class), anyInt()))
+        .thenReturn(verifier);
+
+    Result expected1 = createResult("test1", "value1");
+    Result expected2 = createResult("test2", "value2");
+
+    ResultScanner primaryScannerMock = mock(ResultScanner.class);
+    when(primaryScannerMock.next()).thenReturn(expected1);
+    when(primaryTable.getScanner((Scan) any())).thenReturn(primaryScannerMock);
+
+    ResultScanner secondaryScannerMock = mock(ResultScanner.class);
+    when(secondaryScannerMock.next()).thenReturn(expected2);
+    when(secondaryTable.getScanner((Scan) any())).thenReturn(secondaryScannerMock);
+
+    Scan scan = new Scan();
+    ResultScanner mirroringScanner = spy(mirroringTable.getScanner(scan));
+    assertThat(mirroringScanner.next()).isEqualTo(expected1);
+    verify(mirroringMetricsRecorder, never())
+        .recordReadMismatches(any(HBaseOperation.class), eq(1));
+    waitForMirroringScanner(mirroringScanner);
+
+    verify(verifier, times(1)).verify(any(Result[].class), any(Result[].class));
+    verify(mirroringMetricsRecorder, never())
+        .recordReadMatches(any(HBaseOperation.class), anyInt());
+    verify(mirroringMetricsRecorder, times(2))
+        .recordReadMismatches(any(HBaseOperation.class), eq(1));
+  }
+
+  @Test
+  public void testScannerResultVerifierWithBufferSizeZero()
+      throws IOException, InterruptedException, ExecutionException, TimeoutException {
+    ScannerResultVerifier verifier =
+        spy(mismatchDetector.createScannerResultVerifier(new Scan(), 0));
+    when(mismatchDetector.createScannerResultVerifier(any(Scan.class), anyInt()))
+        .thenReturn(verifier);
+
+    Result expected1 = createResult("test1", "value1");
+    Result expected2 = createResult("test2", "value2");
+    Result expected3 = createResult("test3", "value3");
+    Result expected4 = createResult("test4", "value4");
+    Result expected5 = createResult("test5", "value5");
+    Result expected6 = createResult("test6", "value6");
+    Result expected7 = createResult("test7", "value7");
+
+    ResultScanner primaryScannerMock = mock(ResultScanner.class);
+    when(primaryScannerMock.next())
+        .thenReturn(expected1, expected2, expected3, expected4, expected5, expected6, expected7);
+    when(primaryTable.getScanner((Scan) any())).thenReturn(primaryScannerMock);
+
+    ResultScanner secondaryScannerMock = mock(ResultScanner.class);
+    when(secondaryScannerMock.next())
+        .thenReturn(expected1, expected3, expected5, expected7, null, null, null);
+    when(secondaryTable.getScanner((Scan) any())).thenReturn(secondaryScannerMock);
+
+    Scan scan = new Scan();
+    ResultScanner mirroringScanner = spy(mirroringTable.getScanner(scan));
+    assertThat(mirroringScanner.next()).isEqualTo(expected1);
+    assertThat(mirroringScanner.next()).isEqualTo(expected2);
+    assertThat(mirroringScanner.next()).isEqualTo(expected3);
+    assertThat(mirroringScanner.next()).isEqualTo(expected4);
+    assertThat(mirroringScanner.next()).isEqualTo(expected5);
+    assertThat(mirroringScanner.next()).isEqualTo(expected6);
+    assertThat(mirroringScanner.next()).isEqualTo(expected7);
+    waitForMirroringScanner(mirroringScanner);
+
+    verify(verifier, times(7)).verify(any(Result[].class), any(Result[].class));
+    verify(mirroringMetricsRecorder, times(1)).recordReadMatches(any(HBaseOperation.class), eq(1));
+    verify(mirroringMetricsRecorder, times(9))
+        .recordReadMismatches(any(HBaseOperation.class), eq(1));
+  }
+
+  @Test
+  public void testScannerUnmatchedBufferSpaceRunsOut()
+      throws IOException, InterruptedException, ExecutionException, TimeoutException {
+    ScannerResultVerifier verifier =
+        spy(mismatchDetector.createScannerResultVerifier(new Scan(), 2));
+    when(mismatchDetector.createScannerResultVerifier(any(Scan.class), anyInt()))
+        .thenReturn(verifier);
+
+    Result expected1 = createResult("test1", "value1");
+    Result expected2 = createResult("test2", "value2");
+    Result expected3 = createResult("test3", "value3");
+    Result expected4 = createResult("test4", "value4");
+    Result expected5 = createResult("test5", "value5");
+    Result expected6 = createResult("test6", "value6");
+    Result expected7 = createResult("test7", "value7");
+
+    ResultScanner primaryScannerMock = mock(ResultScanner.class);
+    when(primaryScannerMock.next()).thenReturn(expected1, expected2, expected3, expected4);
+    when(primaryTable.getScanner((Scan) any())).thenReturn(primaryScannerMock);
+
+    ResultScanner secondaryScannerMock = mock(ResultScanner.class);
+    when(secondaryScannerMock.next()).thenReturn(expected4, expected5, expected6, expected7);
+    when(secondaryTable.getScanner((Scan) any())).thenReturn(secondaryScannerMock);
+
+    Scan scan = new Scan();
+    ResultScanner mirroringScanner = spy(mirroringTable.getScanner(scan));
+    assertThat(mirroringScanner.next()).isEqualTo(expected1);
+    assertThat(mirroringScanner.next()).isEqualTo(expected2);
+    assertThat(mirroringScanner.next()).isEqualTo(expected3);
+    assertThat(mirroringScanner.next()).isEqualTo(expected4);
+    waitForMirroringScanner(mirroringScanner);
+
+    verify(verifier, times(4)).verify(any(Result[].class), any(Result[].class));
+    verify(mirroringMetricsRecorder, never())
+        .recordReadMatches(any(HBaseOperation.class), anyInt());
+    verify(mirroringMetricsRecorder, times(8))
+        .recordReadMismatches(any(HBaseOperation.class), eq(1));
+  }
+
+  @Test
+  public void testScannerUnmatchedBufferSpaceRunsOutThenReturnsMatches()
+      throws IOException, InterruptedException, ExecutionException, TimeoutException {
+    ScannerResultVerifier verifier =
+        spy(mismatchDetector.createScannerResultVerifier(new Scan(), 2));
+    when(mismatchDetector.createScannerResultVerifier(any(Scan.class), anyInt()))
+        .thenReturn(verifier);
+
+    Result expected1 = createResult("test1", "value1");
+    Result expected2 = createResult("test2", "value2");
+    Result expected3 = createResult("test3", "value3");
+    Result expected4 = createResult("test4", "value4");
+    Result expected5 = createResult("test5", "value5");
+    Result expected6 = createResult("test6", "value6");
+    Result expected7 = createResult("test7", "value7");
+
+    ResultScanner primaryScannerMock = mock(ResultScanner.class);
+    when(primaryScannerMock.next())
+        .thenReturn(expected1, expected2, expected3, expected4, expected1, expected2, expected3);
+    when(primaryTable.getScanner((Scan) any())).thenReturn(primaryScannerMock);
+
+    ResultScanner secondaryScannerMock = mock(ResultScanner.class);
+    when(secondaryScannerMock.next())
+        .thenReturn(expected4, expected5, expected6, expected7, expected1, expected2, expected3);
+    when(secondaryTable.getScanner((Scan) any())).thenReturn(secondaryScannerMock);
+
+    Scan scan = new Scan();
+    ResultScanner mirroringScanner = spy(mirroringTable.getScanner(scan));
+    assertThat(mirroringScanner.next()).isEqualTo(expected1);
+    assertThat(mirroringScanner.next()).isEqualTo(expected2);
+    assertThat(mirroringScanner.next()).isEqualTo(expected3);
+    assertThat(mirroringScanner.next()).isEqualTo(expected4);
+    assertThat(mirroringScanner.next()).isEqualTo(expected1);
+    assertThat(mirroringScanner.next()).isEqualTo(expected2);
+    assertThat(mirroringScanner.next()).isEqualTo(expected3);
+    waitForMirroringScanner(mirroringScanner);
+
+    verify(verifier, times(7)).verify(any(Result[].class), any(Result[].class));
+    verify(mirroringMetricsRecorder, times(3))
+        .recordReadMatches(any(HBaseOperation.class), anyInt());
+    verify(mirroringMetricsRecorder, times(8))
+        .recordReadMismatches(any(HBaseOperation.class), eq(1));
+  }
+
+  @Test
+  public void testScannerSkippedSomeResults()
+      throws IOException, InterruptedException, ExecutionException, TimeoutException {
+    ScannerResultVerifier verifier =
+        spy(mismatchDetector.createScannerResultVerifier(new Scan(), 100));
+    when(mismatchDetector.createScannerResultVerifier(any(Scan.class), anyInt()))
+        .thenReturn(verifier);
+
+    Result expected1 = createResult("test1", "value1");
+    Result expected2 = createResult("test2", "value2");
+    Result expected3 = createResult("test3", "value3");
+    Result expected4 = createResult("test4", "value4");
+    Result expected5 = createResult("test5", "value5");
+    Result expected6 = createResult("test6", "value6");
+    Result expected7 = createResult("test7", "value7");
+
+    ResultScanner primaryScannerMock = mock(ResultScanner.class);
+    when(primaryScannerMock.next())
+        .thenReturn(expected1, expected2, expected3, expected5, expected6, expected7);
+    when(primaryTable.getScanner((Scan) any())).thenReturn(primaryScannerMock);
+
+    ResultScanner secondaryScannerMock = mock(ResultScanner.class);
+    when(secondaryScannerMock.next())
+        .thenReturn(expected1, expected3, expected4, expected5, expected6, null);
+    when(secondaryTable.getScanner((Scan) any())).thenReturn(secondaryScannerMock);
+
+    Scan scan = new Scan();
+    ResultScanner mirroringScanner = spy(mirroringTable.getScanner(scan));
+    assertThat(mirroringScanner.next()).isEqualTo(expected1);
+    assertThat(mirroringScanner.next()).isEqualTo(expected2);
+    assertThat(mirroringScanner.next()).isEqualTo(expected3);
+    assertThat(mirroringScanner.next()).isEqualTo(expected5);
+    assertThat(mirroringScanner.next()).isEqualTo(expected6);
+    assertThat(mirroringScanner.next()).isEqualTo(expected7);
+    waitForMirroringScanner(mirroringScanner);
+
+    verify(verifier, times(6)).verify(any(Result[].class), any(Result[].class));
+    verify(mirroringMetricsRecorder, times(4))
+        .recordReadMatches(any(HBaseOperation.class), anyInt());
+    verify(mirroringMetricsRecorder, times(3))
+        .recordReadMismatches(any(HBaseOperation.class), eq(1));
   }
 }

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase1_x/TestMirroringTableInputModification.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase1_x/TestMirroringTableInputModification.java
@@ -78,7 +78,7 @@ public class TestMirroringTableInputModification {
   SettableFuture<Void> secondaryOperationBlockingFuture;
 
   @Before
-  public void setUp() {
+  public void setUp() throws IOException, InterruptedException {
     setupFlowControllerMock(flowController);
     this.mirroringTable =
         spy(
@@ -93,8 +93,23 @@ public class TestMirroringTableInputModification {
                 false,
                 false,
                 new MirroringTracer(),
-                mock(ReferenceCounter.class)));
+                mock(ReferenceCounter.class),
+                10));
+
     this.secondaryOperationBlockingFuture = SettableFuture.create();
+
+    mockExistsAll(this.primaryTable);
+    mockGet(this.primaryTable);
+    mockBatch(this.primaryTable);
+
+    secondaryOperationBlockingFuture = SettableFuture.create();
+
+    blockMethodCall(secondaryTable, secondaryOperationBlockingFuture)
+        .existsAll(ArgumentMatchers.<Get>anyList());
+    blockMethodCall(this.secondaryTable, secondaryOperationBlockingFuture)
+        .batch(ArgumentMatchers.<Put>anyList(), (Object[]) any());
+    blockMethodCall(this.secondaryTable, secondaryOperationBlockingFuture)
+        .get(ArgumentMatchers.<Get>anyList());
   }
 
   @Test

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase1_x/TestMirroringTableSynchronousMode.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase1_x/TestMirroringTableSynchronousMode.java
@@ -91,7 +91,8 @@ public class TestMirroringTableSynchronousMode {
                 concurrent,
                 true,
                 new MirroringTracer(),
-                mock(ReferenceCounter.class)));
+                mock(ReferenceCounter.class),
+                5));
   }
 
   @Test

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase1_x/TestVerificationSampling.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase1_x/TestVerificationSampling.java
@@ -94,7 +94,8 @@ public class TestVerificationSampling {
                 false,
                 false,
                 new MirroringTracer(),
-                mock(ReferenceCounter.class)));
+                mock(ReferenceCounter.class),
+                10));
   }
 
   @Test

--- a/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase2_x/MirroringAsyncConnection.java
+++ b/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase2_x/MirroringAsyncConnection.java
@@ -256,7 +256,8 @@ public class MirroringAsyncConnection implements AsyncConnection {
           mirroringTracer,
           readSampler,
           referenceCounter,
-          executorService);
+          executorService,
+          configuration.mirroringOptions.resultScannerBufferedMismatchedResults);
     }
 
     @Override

--- a/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase2_x/MirroringAsyncTable.java
+++ b/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase2_x/MirroringAsyncTable.java
@@ -94,6 +94,7 @@ public class MirroringAsyncTable<C extends ScanResultConsumerBase> implements As
   private final ReadSampler readSampler;
   private final ExecutorService executorService;
   private final RequestScheduler requestScheduler;
+  private final int resultScannerBufferedMismatchedResults;
 
   public MirroringAsyncTable(
       AsyncTable<C> primaryTable,
@@ -104,7 +105,8 @@ public class MirroringAsyncTable<C extends ScanResultConsumerBase> implements As
       MirroringTracer mirroringTracer,
       ReadSampler readSampler,
       ListenableReferenceCounter referenceCounter,
-      ExecutorService executorService) {
+      ExecutorService executorService,
+      int resultScannerBufferedMismatchedResults) {
     this.primaryTable = primaryTable;
     this.secondaryTable = secondaryTable;
     this.verificationContinuationFactory = new VerificationContinuationFactory(mismatchDetector);
@@ -116,6 +118,7 @@ public class MirroringAsyncTable<C extends ScanResultConsumerBase> implements As
     this.executorService = executorService;
     this.requestScheduler =
         new RequestScheduler(this.flowController, this.mirroringTracer, this.referenceCounter);
+    this.resultScannerBufferedMismatchedResults = resultScannerBufferedMismatchedResults;
   }
 
   @Override
@@ -497,7 +500,8 @@ public class MirroringAsyncTable<C extends ScanResultConsumerBase> implements As
         this.mirroringTracer,
         this.readSampler.shouldNextReadOperationBeSampled(),
         this.requestScheduler,
-        this.referenceCounter);
+        this.referenceCounter,
+        this.resultScannerBufferedMismatchedResults);
   }
 
   @Override

--- a/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase2_x/MirroringConnection.java
+++ b/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase2_x/MirroringConnection.java
@@ -87,7 +87,11 @@ public class MirroringConnection
             performWritesConcurrently,
             waitForSecondaryWrites,
             mirroringTracer,
-            referenceCounter);
+            referenceCounter,
+            MirroringConnection.super
+                .configuration
+                .mirroringOptions
+                .resultScannerBufferedMismatchedResults);
       }
     };
   }

--- a/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase2_x/MirroringTable.java
+++ b/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase2_x/MirroringTable.java
@@ -44,7 +44,8 @@ public class MirroringTable extends com.google.cloud.bigtable.mirroring.hbase1_x
       boolean performWritesConcurrently,
       boolean waitForSecondaryWrites,
       MirroringTracer mirroringTracer,
-      ReferenceCounter referenceCounter) {
+      ReferenceCounter referenceCounter,
+      int resultScannerBufferedMismatchedResults) {
     super(
         primaryTable,
         secondaryTable,
@@ -56,7 +57,8 @@ public class MirroringTable extends com.google.cloud.bigtable.mirroring.hbase1_x
         performWritesConcurrently,
         waitForSecondaryWrites,
         mirroringTracer,
-        referenceCounter);
+        referenceCounter,
+        resultScannerBufferedMismatchedResults);
   }
 
   @Override

--- a/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase2_x/TestMirroringAsyncTable.java
+++ b/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase2_x/TestMirroringAsyncTable.java
@@ -118,7 +118,8 @@ public class TestMirroringAsyncTable {
                 new MirroringTracer(),
                 new ReadSampler(100),
                 referenceCounter,
-                executorService));
+                executorService,
+                10));
 
     lenient()
         .doReturn(primaryBuilder)

--- a/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase2_x/TestMirroringAsyncTableInputModification.java
+++ b/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase2_x/TestMirroringAsyncTableInputModification.java
@@ -92,7 +92,8 @@ public class TestMirroringAsyncTableInputModification {
                 new MirroringTracer(),
                 new ReadSampler(100),
                 referenceCounter,
-                executorService));
+                executorService,
+                10));
 
     secondaryOperationBlockedOnFuture = SettableFuture.create();
 

--- a/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase2_x/TestVerificationSampling.java
+++ b/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase2_x/TestVerificationSampling.java
@@ -93,7 +93,8 @@ public class TestVerificationSampling {
                 new MirroringTracer(),
                 readSampler,
                 referenceCounter,
-                executorServiceRule.executorService));
+                executorServiceRule.executorService,
+                10));
   }
 
   public <T, R> T mockWithCompleteFuture(T table, R result) {


### PR DESCRIPTION
I created a single PR as two last points in #121 would require a lot of rebasing should they need to be rewritten.
Warning: there's quite a lot of copypasted code with only ~5 lines of changes in tests in TestMirroringTable (the tests are there instead of in TestMirroringResultScanner because this way there needs to be significantly less boilerplate).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unoperate/java-bigtable-hbase-1/130)
<!-- Reviewable:end -->
