### PR TITLE
fix: force Append and Increment to return results and discard that result before returning it to user

### DIFF
--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/MirroringTable.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/MirroringTable.java
@@ -527,6 +527,7 @@ public class MirroringTable implements Table, ListenableCloseable {
       scheduleSequentialWriteOperation(
           new WriteOperationInfo(put), this.secondaryAsyncWrapper.put(put));
 
+      // HBase's append() returns null when isReturnResults is false.
       return wantsResults ? result : null;
     }
   }

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/OperationUtils.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/OperationUtils.java
@@ -47,41 +47,11 @@ public class OperationUtils {
     return put;
   }
 
-  public interface EmptyResultFactory {
-    Result emptyAppendResult();
-
-    Result emptyIncrementResult();
+  public static Result emptyResult() {
+    return Result.create(new Cell[0]);
   }
 
-  public static class EmptyResultFactory1x implements EmptyResultFactory {
-    public EmptyResultFactory1x() {}
-
-    @Override
-    public Result emptyAppendResult() {
-      return null;
-    }
-
-    @Override
-    public Result emptyIncrementResult() {
-      return Result.create(new Cell[0]);
-    }
-  }
-
-  public static class EmptyResultFactory2x implements EmptyResultFactory {
-    public EmptyResultFactory2x() {}
-
-    @Override
-    public Result emptyAppendResult() {
-      return Result.create(new Cell[0]);
-    }
-
-    @Override
-    public Result emptyIncrementResult() {
-      return Result.create(new Cell[0]);
-    }
-  }
-
-  public static class RewrittenOperations<T extends Row> {
+  public static class RewrittenIncrementAndAppendIndicesInfo<T extends Row> {
     /**
      * Behaviour of HBase when setReturnResults(false) was called on input Append and Increment
      * requests:
@@ -102,11 +72,8 @@ public class OperationUtils {
     public final List<T> operations;
 
     private final Set<Integer> unwantedResultIndices;
-    private final EmptyResultFactory emptyResultFactory;
 
-    public RewrittenOperations(
-        List<? extends T> inputOperations, EmptyResultFactory emptyResultFactory) {
-      this.emptyResultFactory = emptyResultFactory;
+    public RewrittenIncrementAndAppendIndicesInfo(List<? extends T> inputOperations) {
       this.unwantedResultIndices = new HashSet<>();
       this.operations = new ArrayList<>(inputOperations);
       for (int i = 0; i < operations.size(); i++) {
@@ -127,9 +94,9 @@ public class OperationUtils {
           if (results[i] instanceof Result && this.unwantedResultIndices.contains(i)) {
             Row op = this.operations.get(i);
             if (op instanceof Increment) {
-              results[i] = this.emptyResultFactory.emptyIncrementResult();
+              results[i] = emptyResult();
             } else if (op instanceof Append) {
-              results[i] = this.emptyResultFactory.emptyAppendResult();
+              results[i] = emptyResult();
             }
           }
         }

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/OperationUtils.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/OperationUtils.java
@@ -52,23 +52,7 @@ public class OperationUtils {
   }
 
   public static class RewrittenIncrementAndAppendIndicesInfo<T extends Row> {
-    /**
-     * Behaviour of HBase when setReturnResults(false) was called on input Append and Increment
-     * requests:
-     *
-     * <ul>
-     *   <li>HBase 1.4.12
-     *       <ul>
-     *         <li>append(Append): null
-     *         <li>increment(Increment): Result.create(new Cell[0])
-     *         <li>batch(Append): IllegalStateException
-     *         <li>batch(Increment): IllegalStateException
-     *       </ul>
-     *   <li>HBase 2.2.3
-     *       <p>all operations on both Table and AsyncTable return a Result equal to
-     *       Result.create(new Cell[0])
-     * </ul>
-     */
+    /** In batch() when an input Row's isReturnResults is false an empty Result is returned. */
     public final List<T> operations;
 
     private final Set<Integer> unwantedResultIndices;

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/OperationUtils.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/OperationUtils.java
@@ -93,9 +93,7 @@ public class OperationUtils {
         for (int i = 0; i < results.length; i++) {
           if (results[i] instanceof Result && this.unwantedResultIndices.contains(i)) {
             Row op = this.operations.get(i);
-            if (op instanceof Increment) {
-              results[i] = emptyResult();
-            } else if (op instanceof Append) {
+            if (op instanceof Increment || op instanceof Append) {
               results[i] = emptyResult();
             }
           }

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase1_x/TestMirroringTable.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase1_x/TestMirroringTable.java
@@ -1020,8 +1020,6 @@ public class TestMirroringTable {
     verify(primaryTable, times(1)).append(appendCaptor.capture());
     assertThat(appendCaptor.getValue().isReturnResults()).isTrue();
     assertThat(appendWithoutResult).isNull();
-
-    executorServiceRule.waitForExecutor();
   }
 
   @Test
@@ -1046,8 +1044,6 @@ public class TestMirroringTable {
     verify(primaryTable, times(1)).increment(incrementCaptor.capture());
     assertThat(incrementCaptor.getValue().isReturnResults()).isTrue();
     assertThat(incrementWithoutResult.value()).isNull();
-
-    executorServiceRule.waitForExecutor();
   }
 
   @Test
@@ -1075,7 +1071,6 @@ public class TestMirroringTable {
     assertThat(listCaptor.getValue().size()).isEqualTo(1);
     assertThat(((Append) listCaptor.getValue().get(0)).isReturnResults()).isTrue();
     assertThat(((Result) batchAppendWithoutResult[0]).value()).isNull();
-    executorServiceRule.waitForExecutor();
   }
 
   @Test
@@ -1103,7 +1098,6 @@ public class TestMirroringTable {
     assertThat(listCaptor.getValue().size()).isEqualTo(1);
     assertThat(((Increment) listCaptor.getValue().get(0)).isReturnResults()).isTrue();
     assertThat(((Result) batchIncrementWithoutResult[0]).value()).isNull();
-    executorServiceRule.waitForExecutor();
   }
 
   @Test

--- a/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase2_x/MirroringAsyncTable.java
+++ b/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase2_x/MirroringAsyncTable.java
@@ -26,6 +26,9 @@ import com.google.cloud.bigtable.mirroring.hbase1_x.utils.BatchHelpers;
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.BatchHelpers.FailedSuccessfulSplit;
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.BatchHelpers.ReadWriteSplit;
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.ListenableReferenceCounter;
+import com.google.cloud.bigtable.mirroring.hbase1_x.utils.OperationUtils;
+import com.google.cloud.bigtable.mirroring.hbase1_x.utils.OperationUtils.EmptyResultFactory;
+import com.google.cloud.bigtable.mirroring.hbase1_x.utils.OperationUtils.EmptyResultFactory2x;
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.ReadSampler;
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.SecondaryWriteErrorConsumerWithMetrics;
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.flowcontrol.FlowController;
@@ -75,6 +78,8 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
 public class MirroringAsyncTable<C extends ScanResultConsumerBase> implements AsyncTable<C> {
   private final Predicate<Object> resultIsFaultyPredicate = (o) -> o instanceof Throwable;
+  private final EmptyResultFactory emptyResultFactory = new EmptyResultFactory2x();
+
   private final AsyncTable<C> primaryTable;
   private final AsyncTable<C> secondaryTable;
   private final VerificationContinuationFactory verificationContinuationFactory;
@@ -155,14 +160,25 @@ public class MirroringAsyncTable<C extends ScanResultConsumerBase> implements As
 
   @Override
   public CompletableFuture<Result> append(Append append) {
-    CompletableFuture<Result> primaryFuture = this.primaryTable.append(append);
-    return mutationAsPut(primaryFuture).userNotified;
+    boolean wantsResults = append.isReturnResults();
+    CompletableFuture<Result> primaryFuture =
+        this.primaryTable.append(append.setReturnResults(true));
+    return mutationAsPut(primaryFuture)
+        .userNotified
+        .thenApply(
+            primaryResult -> wantsResults ? primaryResult : emptyResultFactory.emptyAppendResult());
   }
 
   @Override
   public CompletableFuture<Result> increment(Increment increment) {
-    CompletableFuture<Result> primaryFuture = this.primaryTable.increment(increment);
-    return mutationAsPut(primaryFuture).userNotified;
+    boolean wantsResults = increment.isReturnResults();
+    CompletableFuture<Result> primaryFuture =
+        this.primaryTable.increment(increment.setReturnResults(true));
+    return mutationAsPut(primaryFuture)
+        .userNotified
+        .thenApply(
+            primaryResult ->
+                wantsResults ? primaryResult : emptyResultFactory.emptyIncrementResult());
   }
 
   @Override
@@ -238,13 +254,15 @@ public class MirroringAsyncTable<C extends ScanResultConsumerBase> implements As
           Function<FailedSuccessfulSplit<ActionType, SuccessfulResultType>, GeneralBatchBuilder>
               batchBuilderCreator,
           Class<SuccessfulResultType> successfulResultTypeClass) {
-    List<ActionType> actions = new ArrayList<>(userActions);
-    final int numActions = actions.size();
+    OperationUtils.RewrittenOperations<ActionType> actions =
+        new OperationUtils.RewrittenOperations<>(userActions, emptyResultFactory);
+    final int numActions = actions.operations.size();
 
     final OperationStages<List<CompletableFuture<ResultType>>> returnedValue =
         new OperationStages<>(generateList(numActions, CompletableFuture<ResultType>::new));
 
-    final List<CompletableFuture<ResultType>> primaryFutures = primaryFunction.apply(actions);
+    final List<CompletableFuture<ResultType>> primaryFutures =
+        primaryFunction.apply(actions.operations);
     final Object[] primaryResults = new Object[numActions];
 
     BiConsumer<Integer, Throwable> primaryErrorHandler =
@@ -255,7 +273,7 @@ public class MirroringAsyncTable<C extends ScanResultConsumerBase> implements As
               boolean skipReads = !readSampler.shouldNextReadOperationBeSampled();
               final FailedSuccessfulSplit<ActionType, SuccessfulResultType> failedSuccessfulSplit =
                   BatchHelpers.createOperationsSplit(
-                      actions,
+                      actions.operations,
                       primaryResults,
                       resultIsFaultyPredicate,
                       successfulResultTypeClass,
@@ -269,7 +287,8 @@ public class MirroringAsyncTable<C extends ScanResultConsumerBase> implements As
                 // - Reads were successful but were excluded from the split due to sampling and we
                 // should forward primary results to a list returned to the user.
                 if (skipReads) {
-                  completeSuccessfulResultFutures(returnedValue.userNotified, primaryResults);
+                  completeSuccessfulResultFutures(
+                      returnedValue.userNotified, primaryResults, actions);
                 }
                 returnedValue.verificationCompleted();
                 return;
@@ -300,7 +319,8 @@ public class MirroringAsyncTable<C extends ScanResultConsumerBase> implements As
 
               resourceReservationRequest.whenComplete(
                   (ignoredResourceReservation, resourceReservationError) -> {
-                    completeSuccessfulResultFutures(returnedValue.userNotified, primaryResults);
+                    completeSuccessfulResultFutures(
+                        returnedValue.userNotified, primaryResults, actions);
                     if (resourceReservationError != null) {
                       if (!successfulReadWriteSplit.writeOperations.isEmpty()) {
                         this.secondaryWriteErrorConsumer.consume(
@@ -334,8 +354,11 @@ public class MirroringAsyncTable<C extends ScanResultConsumerBase> implements As
         .collect(Collectors.toCollection(ArrayList::new));
   }
 
-  private <T> void completeSuccessfulResultFutures(
-      List<CompletableFuture<T>> resultFutures, Object[] primaryResults) {
+  private <T, U extends Row> void completeSuccessfulResultFutures(
+      List<CompletableFuture<T>> resultFutures,
+      Object[] primaryResults,
+      OperationUtils.RewrittenOperations<U> rewrittenOperations) {
+    rewrittenOperations.discardUnwantedResults(primaryResults);
     for (int i = 0; i < primaryResults.length; i++) {
       if (!(resultIsFaultyPredicate.apply(primaryResults[i]))) {
         resultFutures.get(i).complete((T) primaryResults[i]);

--- a/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase2_x/MirroringTable.java
+++ b/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase2_x/MirroringTable.java
@@ -15,6 +15,8 @@
  */
 package com.google.cloud.bigtable.mirroring.hbase2_x;
 
+import com.google.cloud.bigtable.mirroring.hbase1_x.utils.OperationUtils.EmptyResultFactory;
+import com.google.cloud.bigtable.mirroring.hbase1_x.utils.OperationUtils.EmptyResultFactory2x;
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.ReadSampler;
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.SecondaryWriteErrorConsumer;
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.flowcontrol.FlowController;
@@ -29,6 +31,8 @@ import org.apache.hadoop.hbase.client.TableDescriptor;
 
 public class MirroringTable extends com.google.cloud.bigtable.mirroring.hbase1_x.MirroringTable
     implements Table {
+  static EmptyResultFactory emptyResultFactory = new EmptyResultFactory2x();
+
   public MirroringTable(
       Table primaryTable,
       Table secondaryTable,
@@ -61,5 +65,10 @@ public class MirroringTable extends com.google.cloud.bigtable.mirroring.hbase1_x
   @Override
   public boolean[] exists(List<Get> gets) throws IOException {
     return existsAll(gets);
+  }
+
+  @Override
+  protected EmptyResultFactory getEmptyResultFactory() {
+    return emptyResultFactory;
   }
 }

--- a/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase2_x/MirroringTable.java
+++ b/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase2_x/MirroringTable.java
@@ -23,7 +23,10 @@ import com.google.cloud.bigtable.mirroring.hbase1_x.verification.MismatchDetecto
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.client.Append;
 import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.client.TableDescriptor;
 
@@ -61,5 +64,15 @@ public class MirroringTable extends com.google.cloud.bigtable.mirroring.hbase1_x
   @Override
   public boolean[] exists(List<Get> gets) throws IOException {
     return existsAll(gets);
+  }
+
+  /**
+   * HBase 1.x's {@link Table#append} returns {@code null} when {@link Append#isReturnResults} is
+   * {@code false}
+   */
+  @Override
+  public Result append(Append append) throws IOException {
+    Result result = super.append(append);
+    return result == null ? Result.create(new Cell[0]) : result;
   }
 }

--- a/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase2_x/MirroringTable.java
+++ b/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-2.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase2_x/MirroringTable.java
@@ -15,8 +15,6 @@
  */
 package com.google.cloud.bigtable.mirroring.hbase2_x;
 
-import com.google.cloud.bigtable.mirroring.hbase1_x.utils.OperationUtils.EmptyResultFactory;
-import com.google.cloud.bigtable.mirroring.hbase1_x.utils.OperationUtils.EmptyResultFactory2x;
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.ReadSampler;
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.SecondaryWriteErrorConsumer;
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.flowcontrol.FlowController;
@@ -31,8 +29,6 @@ import org.apache.hadoop.hbase.client.TableDescriptor;
 
 public class MirroringTable extends com.google.cloud.bigtable.mirroring.hbase1_x.MirroringTable
     implements Table {
-  static EmptyResultFactory emptyResultFactory = new EmptyResultFactory2x();
-
   public MirroringTable(
       Table primaryTable,
       Table secondaryTable,
@@ -65,10 +61,5 @@ public class MirroringTable extends com.google.cloud.bigtable.mirroring.hbase1_x
   @Override
   public boolean[] exists(List<Get> gets) throws IOException {
     return existsAll(gets);
-  }
-
-  @Override
-  protected EmptyResultFactory getEmptyResultFactory() {
-    return emptyResultFactory;
   }
 }


### PR DESCRIPTION
The name of the PR is WIP.
I only checked HBase 2.x behaviour for now.
We still probably need to implement similiar batch-append/increment result ignoring in https://github.com/Unoperate/java-bigtable-hbase-1/pull/116
The tests suddenly refused to be run so I leave it as a draft for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unoperate/java-bigtable-hbase-1/136)
<!-- Reviewable:end -->
