### PR TITLE
refactor: rename WRITE_MISMATCH to SECONDARY_WRITE_ERROR

### DIFF
--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/SecondaryWriteErrorConsumerWithMetrics.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/SecondaryWriteErrorConsumerWithMetrics.java
@@ -32,13 +32,13 @@ public class SecondaryWriteErrorConsumerWithMetrics implements SecondaryWriteErr
 
   @Override
   public void consume(HBaseOperation operation, List<? extends Row> operations, Throwable cause) {
-    this.mirroringTracer.metricsRecorder.recordWriteMismatches(operation, operations.size());
+    this.mirroringTracer.metricsRecorder.recordSecondaryWriteErrors(operation, operations.size());
     this.secondaryWriteErrorConsumer.consume(operation, operations, cause);
   }
 
   @Override
   public void consume(HBaseOperation operation, Row row, Throwable cause) {
-    this.mirroringTracer.metricsRecorder.recordWriteMismatches(operation, 1);
+    this.mirroringTracer.metricsRecorder.recordSecondaryWriteErrors(operation, 1);
     this.secondaryWriteErrorConsumer.consume(operation, row, cause);
   }
 }

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/mirroringmetrics/MirroringMetricsRecorder.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/mirroringmetrics/MirroringMetricsRecorder.java
@@ -17,7 +17,7 @@ package com.google.cloud.bigtable.mirroring.hbase1_x.utils.mirroringmetrics;
 
 import static com.google.cloud.bigtable.mirroring.hbase1_x.utils.mirroringmetrics.MirroringSpanConstants.OPERATION_KEY;
 import static com.google.cloud.bigtable.mirroring.hbase1_x.utils.mirroringmetrics.MirroringSpanConstants.READ_MISMATCHES;
-import static com.google.cloud.bigtable.mirroring.hbase1_x.utils.mirroringmetrics.MirroringSpanConstants.WRITE_MISMATCHES;
+import static com.google.cloud.bigtable.mirroring.hbase1_x.utils.mirroringmetrics.MirroringSpanConstants.SECONDARY_WRITE_ERRORS;
 
 import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.mirroringmetrics.MirroringSpanConstants.HBaseOperation;
@@ -72,10 +72,10 @@ public class MirroringMetricsRecorder {
     map.record(tagContext);
   }
 
-  public void recordWriteMismatches(HBaseOperation operation, int numberOfMismatches) {
+  public void recordSecondaryWriteErrors(HBaseOperation operation, int numberOfErrors) {
     TagContext tagContext = getTagContext(operation);
     MeasureMap map = statsRecorder.newMeasureMap();
-    map.put(WRITE_MISMATCHES, numberOfMismatches);
+    map.put(SECONDARY_WRITE_ERRORS, numberOfErrors);
     map.record(tagContext);
   }
 }

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/mirroringmetrics/MirroringMetricsViews.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/mirroringmetrics/MirroringMetricsViews.java
@@ -22,7 +22,7 @@ import static com.google.cloud.bigtable.mirroring.hbase1_x.utils.mirroringmetric
 import static com.google.cloud.bigtable.mirroring.hbase1_x.utils.mirroringmetrics.MirroringSpanConstants.READ_MISMATCHES;
 import static com.google.cloud.bigtable.mirroring.hbase1_x.utils.mirroringmetrics.MirroringSpanConstants.SECONDARY_ERRORS;
 import static com.google.cloud.bigtable.mirroring.hbase1_x.utils.mirroringmetrics.MirroringSpanConstants.SECONDARY_LATENCY;
-import static com.google.cloud.bigtable.mirroring.hbase1_x.utils.mirroringmetrics.MirroringSpanConstants.WRITE_MISMATCHES;
+import static com.google.cloud.bigtable.mirroring.hbase1_x.utils.mirroringmetrics.MirroringSpanConstants.SECONDARY_WRITE_ERRORS;
 
 import com.google.api.core.InternalApi;
 import com.google.common.collect.ImmutableList;
@@ -107,12 +107,12 @@ public class MirroringMetricsViews {
           SUM,
           ImmutableList.of(OPERATION_KEY));
 
-  /** {@link View} for Mirroring client's secondary write mismatches. */
-  private static final View WRITE_MISMATCH_VIEW =
+  /** {@link View} for Mirroring client's secondary database write errors. */
+  private static final View SECONDARY_WRITE_ERROR_VIEW =
       View.create(
-          View.Name.create("cloud.google.com/java/mirroring/write_mismatch"),
-          "Detected write mismatches count.",
-          WRITE_MISMATCHES,
+          View.Name.create("cloud.google.com/java/mirroring/secondary_write_error"),
+          "Secondary database write error count.",
+          SECONDARY_WRITE_ERRORS,
           SUM,
           ImmutableList.of(OPERATION_KEY));
 
@@ -124,7 +124,7 @@ public class MirroringMetricsViews {
           SECONDARY_OPERATION_ERROR_VIEW,
           MIRRORING_OPERATION_LATENCY_VIEW,
           READ_MISMATCH_VIEW,
-          WRITE_MISMATCH_VIEW);
+          SECONDARY_WRITE_ERROR_VIEW);
 
   /** Registers all Mirroring client views to OpenCensus View. */
   public static void registerMirroringClientViews() {

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/mirroringmetrics/MirroringSpanConstants.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/mirroringmetrics/MirroringSpanConstants.java
@@ -58,9 +58,11 @@ public class MirroringSpanConstants {
           "Count of read mismatches detected.",
           "1");
 
-  public static final MeasureLong WRITE_MISMATCHES =
+  public static final MeasureLong SECONDARY_WRITE_ERRORS =
       MeasureLong.create(
-          "com/google/cloud/bigtable/mirroring/mismatch/write", "Count of write mismatches.", "1");
+          "com/google/cloud/bigtable/mirroring/secondary/write_error_rate",
+          "Count of write errors on secondary database.",
+          "1");
 
   public static TagKey OPERATION_KEY = TagKey.create("operation");
 

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase1_x/TestMirroringMetrics.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase1_x/TestMirroringMetrics.java
@@ -140,7 +140,7 @@ public class TestMirroringMetrics {
     verify(mirroringMetricsRecorder, never())
         .recordReadMismatches(any(HBaseOperation.class), anyInt());
     verify(mirroringMetricsRecorder, never())
-        .recordWriteMismatches(any(HBaseOperation.class), anyInt());
+        .recordSecondaryWriteErrors(any(HBaseOperation.class), anyInt());
   }
 
   @Test
@@ -157,7 +157,7 @@ public class TestMirroringMetrics {
 
     verify(mirroringMetricsRecorder, times(1)).recordReadMismatches(HBaseOperation.GET, 1);
     verify(mirroringMetricsRecorder, never())
-        .recordWriteMismatches(any(HBaseOperation.class), anyInt());
+        .recordSecondaryWriteErrors(any(HBaseOperation.class), anyInt());
   }
 
   @Test
@@ -194,7 +194,7 @@ public class TestMirroringMetrics {
     verify(mirroringMetricsRecorder, never())
         .recordReadMismatches(any(HBaseOperation.class), anyInt());
     verify(mirroringMetricsRecorder, never())
-        .recordWriteMismatches(any(HBaseOperation.class), anyInt());
+        .recordSecondaryWriteErrors(any(HBaseOperation.class), anyInt());
   }
 
   @Test
@@ -227,7 +227,7 @@ public class TestMirroringMetrics {
     verify(mirroringMetricsRecorder, never())
         .recordReadMismatches(any(HBaseOperation.class), anyInt());
     verify(mirroringMetricsRecorder, never())
-        .recordWriteMismatches(any(HBaseOperation.class), anyInt());
+        .recordSecondaryWriteErrors(any(HBaseOperation.class), anyInt());
   }
 
   @Test
@@ -261,7 +261,7 @@ public class TestMirroringMetrics {
 
     verify(mirroringMetricsRecorder, never())
         .recordReadMismatches(any(HBaseOperation.class), anyInt());
-    verify(mirroringMetricsRecorder, times(1)).recordWriteMismatches(HBaseOperation.BATCH, 1);
+    verify(mirroringMetricsRecorder, times(1)).recordSecondaryWriteErrors(HBaseOperation.BATCH, 1);
   }
 
   @Test
@@ -334,7 +334,7 @@ public class TestMirroringMetrics {
 
     verify(mirroringMetricsRecorder, never())
         .recordReadMismatches(any(HBaseOperation.class), anyInt());
-    verify(mirroringMetricsRecorder, times(2)).recordWriteMismatches(HBaseOperation.BATCH, 1);
+    verify(mirroringMetricsRecorder, times(2)).recordSecondaryWriteErrors(HBaseOperation.BATCH, 1);
   }
 
   @Test
@@ -354,12 +354,13 @@ public class TestMirroringMetrics {
     secondaryWriteErrorConsumerWithMetrics.consume(HBaseOperation.PUT_LIST, puts, new Throwable());
     verify(secondaryWriteErrorConsumer, times(1))
         .consume(eq(HBaseOperation.PUT_LIST), eq(puts), any(Throwable.class));
-    verify(mirroringMetricsRecorder, times(1)).recordWriteMismatches(HBaseOperation.PUT_LIST, 2);
+    verify(mirroringMetricsRecorder, times(1))
+        .recordSecondaryWriteErrors(HBaseOperation.PUT_LIST, 2);
 
     Put put = createPut("r1", "f", "q", "1");
     secondaryWriteErrorConsumerWithMetrics.consume(HBaseOperation.PUT, put, new Throwable());
 
-    verify(mirroringMetricsRecorder, times(1)).recordWriteMismatches(HBaseOperation.PUT, 1);
+    verify(mirroringMetricsRecorder, times(1)).recordSecondaryWriteErrors(HBaseOperation.PUT, 1);
     verify(secondaryWriteErrorConsumer, times(1))
         .consume(eq(HBaseOperation.PUT), eq(put), any(Throwable.class));
 
@@ -369,6 +370,7 @@ public class TestMirroringMetrics {
 
     verify(secondaryWriteErrorConsumer, times(1))
         .consume(eq(HBaseOperation.MUTATE_ROW), eq(rowMutations), any(Throwable.class));
-    verify(mirroringMetricsRecorder, times(1)).recordWriteMismatches(HBaseOperation.MUTATE_ROW, 1);
+    verify(mirroringMetricsRecorder, times(1))
+        .recordSecondaryWriteErrors(HBaseOperation.MUTATE_ROW, 1);
   }
 }


### PR DESCRIPTION
Requested here https://github.com/Unoperate/java-bigtable-hbase-1/pull/129#pullrequestreview-797713124

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unoperate/java-bigtable-hbase-1/138)
<!-- Reviewable:end -->
