### PR TITLE
refactor: Apply faillog comments.

### DIFF
--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/mirroring/TestMirroringTable.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/mirroring/TestMirroringTable.java
@@ -30,7 +30,7 @@ import com.google.cloud.bigtable.hbase.mirroring.utils.failinghbaseminicluster.F
 import com.google.cloud.bigtable.hbase.mirroring.utils.failinghbaseminicluster.FailingHBaseHRegionRule;
 import com.google.cloud.bigtable.mirroring.hbase1_x.ExecutorServiceRule;
 import com.google.cloud.bigtable.mirroring.hbase1_x.MirroringConnection;
-import com.google.cloud.bigtable.mirroring.hbase1_x.utils.faillog.DefaultAppender;
+import com.google.cloud.bigtable.mirroring.hbase1_x.MirroringOptions;
 import com.google.common.base.Predicate;
 import com.google.common.primitives.Longs;
 import java.io.File;
@@ -1233,7 +1233,8 @@ public class TestMirroringTable {
 
   private static int getSecondaryWriteErrorLogMessagesWritten() throws IOException {
     Configuration configuration = ConfigurationHelper.newConfiguration();
-    String prefixPath = configuration.get(DefaultAppender.PREFIX_PATH_KEY);
+    MirroringOptions mirroringOptions = new MirroringOptions(configuration);
+    String prefixPath = configuration.get(mirroringOptions.faillog.prefix_path_key);
     String[] prefixParts = prefixPath.split("/");
     final String fileNamePrefix = prefixParts[prefixParts.length - 1];
     String[] directoryParts = Arrays.copyOf(prefixParts, prefixParts.length - 1);

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/mirroring/utils/TestWriteErrorConsumer.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/mirroring/utils/TestWriteErrorConsumer.java
@@ -17,7 +17,7 @@ package com.google.cloud.bigtable.hbase.mirroring.utils;
 
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.DefaultSecondaryWriteErrorConsumer;
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.SecondaryWriteErrorConsumer;
-import com.google.cloud.bigtable.mirroring.hbase1_x.utils.faillog.Logger;
+import com.google.cloud.bigtable.mirroring.hbase1_x.utils.faillog.FailedMutationLogger;
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.mirroringmetrics.MirroringSpanConstants.HBaseOperation;
 import com.google.common.base.Preconditions;
 import java.util.List;
@@ -30,8 +30,8 @@ public class TestWriteErrorConsumer implements SecondaryWriteErrorConsumer {
   static AtomicInteger errorCount = new AtomicInteger(0);
   private final DefaultSecondaryWriteErrorConsumer secondaryWriteErrorConsumer;
 
-  public TestWriteErrorConsumer(Logger writeErrorLogger) {
-    this.secondaryWriteErrorConsumer = new DefaultSecondaryWriteErrorConsumer(writeErrorLogger);
+  public TestWriteErrorConsumer(FailedMutationLogger failedMutationLogger) {
+    this.secondaryWriteErrorConsumer = new DefaultSecondaryWriteErrorConsumer(failedMutationLogger);
   }
 
   public static int getErrorCount() {
@@ -60,8 +60,8 @@ public class TestWriteErrorConsumer implements SecondaryWriteErrorConsumer {
 
   public static class Factory implements SecondaryWriteErrorConsumer.Factory {
     @Override
-    public SecondaryWriteErrorConsumer create(Logger logger) {
-      return new TestWriteErrorConsumer(logger);
+    public SecondaryWriteErrorConsumer create(FailedMutationLogger failedMutationLogger) {
+      return new TestWriteErrorConsumer(failedMutationLogger);
     }
   }
 }

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/MirroringConnection.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/MirroringConnection.java
@@ -22,7 +22,7 @@ import com.google.cloud.bigtable.mirroring.hbase1_x.utils.ListenableReferenceCou
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.ReadSampler;
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.SecondaryWriteErrorConsumer;
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.SecondaryWriteErrorConsumerWithMetrics;
-import com.google.cloud.bigtable.mirroring.hbase1_x.utils.faillog.Logger;
+import com.google.cloud.bigtable.mirroring.hbase1_x.utils.faillog.FailedMutationLogger;
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.flowcontrol.FlowController;
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.mirroringmetrics.MirroringSpanConstants.HBaseOperation;
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.mirroringmetrics.MirroringTracer;
@@ -57,7 +57,7 @@ public class MirroringConnection implements Connection {
   protected final MirroringTracer mirroringTracer;
   protected final SecondaryWriteErrorConsumer secondaryWriteErrorConsumer;
   protected final ReadSampler readSampler;
-  private final Logger failedWritesLogger;
+  private final FailedMutationLogger failedMutationLogger;
   private final MirroringConfiguration configuration;
   private final Connection primaryConnection;
   private final Connection secondaryConnection;
@@ -107,15 +107,18 @@ public class MirroringConnection implements Connection {
             .newInstance()
             .create(this.mirroringTracer);
 
-    this.failedWritesLogger =
-        new Logger(
+    this.failedMutationLogger =
+        new FailedMutationLogger(
+            mirroringTracer,
             this.configuration
                 .mirroringOptions
+                .faillog
                 .writeErrorLogAppenderFactoryClass
                 .newInstance()
-                .create(this.configuration.baseConfiguration),
+                .create(this.configuration.mirroringOptions.faillog),
             this.configuration
                 .mirroringOptions
+                .faillog
                 .writeErrorLogSerializerFactoryClass
                 .newInstance()
                 .create());
@@ -125,7 +128,7 @@ public class MirroringConnection implements Connection {
             .mirroringOptions
             .writeErrorConsumerFactoryClass
             .newInstance()
-            .create(this.failedWritesLogger);
+            .create(this.failedMutationLogger);
 
     this.secondaryWriteErrorConsumer =
         new SecondaryWriteErrorConsumerWithMetrics(
@@ -228,7 +231,7 @@ public class MirroringConnection implements Connection {
         throw wrapperException;
       } finally {
         try {
-          this.failedWritesLogger.close();
+          this.failedMutationLogger.close();
         } catch (Exception e) {
           throw new IOException(e);
         }

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/MirroringOptions.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/MirroringOptions.java
@@ -17,6 +17,9 @@ package com.google.cloud.bigtable.mirroring.hbase1_x;
 
 import static com.google.cloud.bigtable.mirroring.hbase1_x.utils.MirroringConfigurationHelper.MIRRORING_BUFFERED_MUTATOR_BYTES_TO_FLUSH;
 import static com.google.cloud.bigtable.mirroring.hbase1_x.utils.MirroringConfigurationHelper.MIRRORING_CONCURRENT_WRITES;
+import static com.google.cloud.bigtable.mirroring.hbase1_x.utils.MirroringConfigurationHelper.MIRRORING_FAILLOG_DROP_ON_OVERFLOW_KEY;
+import static com.google.cloud.bigtable.mirroring.hbase1_x.utils.MirroringConfigurationHelper.MIRRORING_FAILLOG_MAX_BUFFER_SIZE_KEY;
+import static com.google.cloud.bigtable.mirroring.hbase1_x.utils.MirroringConfigurationHelper.MIRRORING_FAILLOG_PREFIX_PATH_KEY;
 import static com.google.cloud.bigtable.mirroring.hbase1_x.utils.MirroringConfigurationHelper.MIRRORING_FLOW_CONTROLLER_MAX_OUTSTANDING_REQUESTS;
 import static com.google.cloud.bigtable.mirroring.hbase1_x.utils.MirroringConfigurationHelper.MIRRORING_FLOW_CONTROLLER_MAX_USED_BYTES;
 import static com.google.cloud.bigtable.mirroring.hbase1_x.utils.MirroringConfigurationHelper.MIRRORING_FLOW_CONTROLLER_STRATEGY_FACTORY_CLASS;
@@ -43,6 +46,31 @@ import org.apache.hadoop.conf.Configuration;
 
 @InternalApi("For internal use only")
 public class MirroringOptions {
+  public static class Faillog {
+    Faillog(Configuration configuration) {
+      prefix_path_key = configuration.get(MIRRORING_FAILLOG_PREFIX_PATH_KEY);
+      max_buffer_size =
+          configuration.getInt(MIRRORING_FAILLOG_MAX_BUFFER_SIZE_KEY, 20 * 1024 * 1024);
+      drop_on_overflow = configuration.getBoolean(MIRRORING_FAILLOG_DROP_ON_OVERFLOW_KEY, false);
+      this.writeErrorLogAppenderFactoryClass =
+          configuration.getClass(
+              MIRRORING_WRITE_ERROR_LOG_APPENDER_FACTORY_CLASS,
+              DefaultAppender.Factory.class,
+              Appender.Factory.class);
+      this.writeErrorLogSerializerFactoryClass =
+          configuration.getClass(
+              MIRRORING_WRITE_ERROR_LOG_SERIALIZER_FACTORY_CLASS,
+              DefaultSerializer.Factory.class,
+              Serializer.Factory.class);
+    }
+
+    public final Class<? extends Appender.Factory> writeErrorLogAppenderFactoryClass;
+    public final Class<? extends Serializer.Factory> writeErrorLogSerializerFactoryClass;
+    public final String prefix_path_key;
+    public final int max_buffer_size;
+    public final boolean drop_on_overflow;
+  };
+
   private static final String HBASE_CLIENT_WRITE_BUFFER_KEY = "hbase.client.write.buffer";
 
   public final Class<? extends MismatchDetector.Factory> mismatchDetectorFactoryClass;
@@ -53,13 +81,12 @@ public class MirroringOptions {
   public final Class<? extends SecondaryWriteErrorConsumer.Factory> writeErrorConsumerFactoryClass;
   public final int readSamplingRate;
 
-  public final Class<? extends Appender.Factory> writeErrorLogAppenderFactoryClass;
-  public final Class<? extends Serializer.Factory> writeErrorLogSerializerFactoryClass;
-
   public final boolean performWritesConcurrently;
   public final boolean waitForSecondaryWrites;
+  public final Faillog faillog;
 
   public MirroringOptions(Configuration configuration) {
+
     this.mismatchDetectorFactoryClass =
         configuration.getClass(
             MIRRORING_MISMATCH_DETECTOR_FACTORY_CLASS,
@@ -86,16 +113,6 @@ public class MirroringOptions {
     this.readSamplingRate = configuration.getInt(MIRRORING_READ_VERIFICATION_RATE_PERCENT, 100);
     Preconditions.checkArgument(this.readSamplingRate >= 0);
     Preconditions.checkArgument(this.readSamplingRate <= 100);
-    this.writeErrorLogAppenderFactoryClass =
-        configuration.getClass(
-            MIRRORING_WRITE_ERROR_LOG_APPENDER_FACTORY_CLASS,
-            DefaultAppender.Factory.class,
-            Appender.Factory.class);
-    this.writeErrorLogSerializerFactoryClass =
-        configuration.getClass(
-            MIRRORING_WRITE_ERROR_LOG_SERIALIZER_FACTORY_CLASS,
-            DefaultSerializer.Factory.class,
-            Serializer.Factory.class);
     this.performWritesConcurrently = configuration.getBoolean(MIRRORING_CONCURRENT_WRITES, false);
     this.waitForSecondaryWrites = configuration.getBoolean(MIRRORING_SYNCHRONOUS_WRITES, false);
 
@@ -103,5 +120,6 @@ public class MirroringOptions {
         !(this.performWritesConcurrently && !this.waitForSecondaryWrites),
         "Performing writes concurrently and not waiting for writes is forbidden. "
             + "It has no advantage over performing writes asynchronously and not waiting for them.");
+    this.faillog = new Faillog(configuration);
   }
 }

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/DefaultSecondaryWriteErrorConsumer.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/DefaultSecondaryWriteErrorConsumer.java
@@ -15,7 +15,7 @@
  */
 package com.google.cloud.bigtable.mirroring.hbase1_x.utils;
 
-import com.google.cloud.bigtable.mirroring.hbase1_x.utils.faillog.Logger;
+import com.google.cloud.bigtable.mirroring.hbase1_x.utils.faillog.FailedMutationLogger;
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.mirroringmetrics.MirroringSpanConstants.HBaseOperation;
 import java.util.List;
 import org.apache.hadoop.hbase.client.Mutation;
@@ -24,21 +24,21 @@ import org.apache.hadoop.hbase.client.RowMutations;
 
 /**
  * Default implementation of {@link SecondaryWriteErrorConsumer} which forwards write errors to
- * {@link Logger}.
+ * {@link FailedMutationLogger}.
  */
 public class DefaultSecondaryWriteErrorConsumer implements SecondaryWriteErrorConsumer {
   private static final com.google.cloud.bigtable.mirroring.hbase1_x.utils.Logger Log =
       new com.google.cloud.bigtable.mirroring.hbase1_x.utils.Logger(
           DefaultSecondaryWriteErrorConsumer.class);
-  private final Logger writeErrorLogger;
+  private final FailedMutationLogger failedMutationLogger;
 
-  public DefaultSecondaryWriteErrorConsumer(Logger writeErrorLogger) {
-    this.writeErrorLogger = writeErrorLogger;
+  public DefaultSecondaryWriteErrorConsumer(FailedMutationLogger failedMutationLogger) {
+    this.failedMutationLogger = failedMutationLogger;
   }
 
   private void consume(Mutation r, Throwable cause) {
     try {
-      writeErrorLogger.mutationFailed(r, cause);
+      failedMutationLogger.mutationFailed(r, cause);
     } catch (InterruptedException e) {
       Log.error(
           "Writing mutation that failed on secondary database to faillog interrupted: mutation=%s, failure_cause=%s, exception=%s",
@@ -73,8 +73,8 @@ public class DefaultSecondaryWriteErrorConsumer implements SecondaryWriteErrorCo
 
   public static class Factory implements SecondaryWriteErrorConsumer.Factory {
     @Override
-    public SecondaryWriteErrorConsumer create(Logger logger) {
-      return new DefaultSecondaryWriteErrorConsumer(logger);
+    public SecondaryWriteErrorConsumer create(FailedMutationLogger failedMutationLogger) {
+      return new DefaultSecondaryWriteErrorConsumer(failedMutationLogger);
     }
   }
 }

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/MirroringConfigurationHelper.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/MirroringConfigurationHelper.java
@@ -143,6 +143,40 @@ public class MirroringConfigurationHelper {
   public static final String MIRRORING_SYNCHRONOUS_WRITES =
       "google.bigtable.mirroring.synchronous-writes";
 
+  /**
+   * Determines the path prefix used for generating the failed mutations log file names.
+   *
+   * <p>In default mode secondary mutations are executed asynchronously, so their status is not
+   * reported to the user. Instead, they are logged to a failed mutation log, which can be inspected
+   * manually, collected or read programatically to retry the mutations.
+   *
+   * <p>This property should not be empty. Example value: {@code
+   * "/tmp/hbase_mirroring_client_failed_mutations"}.
+   */
+  public static final String MIRRORING_FAILLOG_PREFIX_PATH_KEY =
+      "google.bigtable.mirroring.write-error-log.appender.prefix-path";
+
+  /**
+   * Maximum size of the buffer holding failed mutations before they are logged to persistent
+   * storage.
+   *
+   * <p>Defaults to {@code 20 * 1024 * 1024}.
+   */
+  public static final String MIRRORING_FAILLOG_MAX_BUFFER_SIZE_KEY =
+      "google.bigtable.mirroring.write-error-log.appender.max-buffer-size";
+
+  /**
+   * Controls the behavior of the failed mutation log on persistent storage not keeping up with
+   * writing the mutations.
+   *
+   * <p>If set to {@code true}, mutations will be dropped, otherwise they will block the thread
+   * until the storage catches up.
+   *
+   * <p>Defaults to {@code false}.
+   */
+  public static final String MIRRORING_FAILLOG_DROP_ON_OVERFLOW_KEY =
+      "google.bigtable.mirroring.write-error-log.appender.drop-on-overflow";
+
   public static void fillConnectionConfigWithClassImplementation(
       Configuration connectionConfig,
       Configuration config,

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/SecondaryWriteErrorConsumer.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/SecondaryWriteErrorConsumer.java
@@ -16,7 +16,7 @@
 package com.google.cloud.bigtable.mirroring.hbase1_x.utils;
 
 import com.google.api.core.InternalApi;
-import com.google.cloud.bigtable.mirroring.hbase1_x.utils.faillog.Logger;
+import com.google.cloud.bigtable.mirroring.hbase1_x.utils.faillog.FailedMutationLogger;
 import com.google.cloud.bigtable.mirroring.hbase1_x.utils.mirroringmetrics.MirroringSpanConstants.HBaseOperation;
 import java.util.List;
 import org.apache.hadoop.hbase.client.Row;
@@ -27,7 +27,7 @@ import org.apache.hadoop.hbase.client.Row;
  * that succeeded on primary database but have failed on the secondary.
  *
  * <p>Default implementation ({@link DefaultSecondaryWriteErrorConsumer}) forwards those writes to
- * {@link Logger} (which, by default, writes them to on-disk log).
+ * {@link FailedMutationLogger} (which, by default, writes them to on-disk log).
  */
 @InternalApi("For internal usage only")
 public interface SecondaryWriteErrorConsumer {
@@ -36,6 +36,6 @@ public interface SecondaryWriteErrorConsumer {
   void consume(HBaseOperation operation, List<? extends Row> operations, Throwable cause);
 
   interface Factory {
-    SecondaryWriteErrorConsumer create(Logger logger) throws Throwable;
+    SecondaryWriteErrorConsumer create(FailedMutationLogger failedMutationLogger) throws Throwable;
   }
 }

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/faillog/Appender.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/faillog/Appender.java
@@ -15,7 +15,7 @@
  */
 package com.google.cloud.bigtable.mirroring.hbase1_x.utils.faillog;
 
-import org.apache.hadoop.conf.Configuration;
+import com.google.cloud.bigtable.mirroring.hbase1_x.MirroringOptions;
 
 /**
  * Objects of this class should write log entries somewhere.
@@ -26,6 +26,6 @@ public interface Appender extends AutoCloseable {
   void append(byte[] data) throws InterruptedException;
 
   interface Factory {
-    Appender create(Configuration configuration) throws Throwable;
+    Appender create(MirroringOptions.Faillog options) throws Throwable;
   }
 }

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/faillog/DefaultAppender.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/faillog/DefaultAppender.java
@@ -19,7 +19,7 @@ import static java.nio.file.StandardOpenOption.CREATE_NEW;
 import static java.nio.file.StandardOpenOption.SYNC;
 import static java.nio.file.StandardOpenOption.WRITE;
 
-import com.google.common.base.Preconditions;
+import com.google.cloud.bigtable.mirroring.hbase1_x.MirroringOptions;
 import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -31,7 +31,6 @@ import java.util.Queue;
 import java.util.TimeZone;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.hadoop.conf.Configuration;
 
 /**
  * Write log entries asynchronously.
@@ -46,22 +45,12 @@ public class DefaultAppender implements Appender {
   private final LogBuffer buffer;
   private final Writer writer;
 
-  public static final String PREFIX_PATH_KEY =
-      "google.bigtable.mirroring.write-error-log.appender.prefix-path";
-  public static final String MAX_BUFFER_SIZE_KEY =
-      "google.bigtable.mirroring.write-error-log.appender.max-buffer-size";
-  public static final String DROP_ON_OVERFLOW_KEY =
-      "google.bigtable.mirroring.write-error-log.appender.drop-on-overflow";
-
-  public DefaultAppender(Configuration configuration) throws IOException {
-    this(
-        getPrefixPathFromConfiguration(configuration),
-        getMaxBufferSizeFromConfiguration(configuration),
-        getDropOnOverflowFromConfiguration(configuration));
+  public DefaultAppender(MirroringOptions.Faillog options) throws IOException {
+    this(options.prefix_path_key, options.max_buffer_size, options.drop_on_overflow);
   }
 
   /**
-   * Create an `DefaultAppender`.
+   * Create a `DefaultAppender`.
    *
    * <p>The created `DefaultAppender` will create a thread for flushing the data asynchronously. The
    * data will be transferred to the thread via a buffer of a given maximum size (`maxBufferSize`).
@@ -180,47 +169,10 @@ public class DefaultAppender implements Appender {
     }
   }
 
-  private static boolean getDropOnOverflowFromConfiguration(Configuration configuration) {
-    String dropOnOverflow = configuration.get(DROP_ON_OVERFLOW_KEY, "false");
-    Preconditions.checkArgument(
-        dropOnOverflow != null && !dropOnOverflow.isEmpty(),
-        "DefaultAppender's %s key shouldn't be empty.",
-        DROP_ON_OVERFLOW_KEY);
-    try {
-      return Boolean.parseBoolean(dropOnOverflow);
-    } catch (NumberFormatException e) {
-      throw new IllegalArgumentException(
-          String.format("DefaultAppender's %s key should be a boolean.", DROP_ON_OVERFLOW_KEY));
-    }
-  }
-
-  private static int getMaxBufferSizeFromConfiguration(Configuration configuration) {
-    String maxBufferSize = configuration.get(MAX_BUFFER_SIZE_KEY, "20971520");
-    Preconditions.checkArgument(
-        maxBufferSize != null && !maxBufferSize.isEmpty(),
-        "DefaultAppender's %s key shouldn't be empty.",
-        MAX_BUFFER_SIZE_KEY);
-    try {
-      return Integer.parseInt(maxBufferSize);
-    } catch (NumberFormatException e) {
-      throw new IllegalArgumentException(
-          String.format("DefaultAppender's %s key should be a integer.", MAX_BUFFER_SIZE_KEY));
-    }
-  }
-
-  private static String getPrefixPathFromConfiguration(Configuration configuration) {
-    String prefixPath = configuration.get(PREFIX_PATH_KEY);
-    Preconditions.checkArgument(
-        prefixPath != null && !prefixPath.isEmpty(),
-        "DefaultAppender's %s key shouldn't be empty.",
-        PREFIX_PATH_KEY);
-    return prefixPath;
-  }
-
   public static class Factory implements Appender.Factory {
     @Override
-    public Appender create(Configuration configuration) throws IOException {
-      return new DefaultAppender(configuration);
+    public Appender create(MirroringOptions.Faillog options) throws IOException {
+      return new DefaultAppender(options);
     }
   }
 }

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/faillog/FailedMutationLogger.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/faillog/FailedMutationLogger.java
@@ -15,6 +15,9 @@
  */
 package com.google.cloud.bigtable.mirroring.hbase1_x.utils.faillog;
 
+import com.google.cloud.bigtable.mirroring.hbase1_x.utils.mirroringmetrics.MirroringSpanConstants;
+import com.google.cloud.bigtable.mirroring.hbase1_x.utils.mirroringmetrics.MirroringTracer;
+import io.opencensus.common.Scope;
 import java.io.IOException;
 import org.apache.hadoop.hbase.client.Mutation;
 
@@ -23,12 +26,13 @@ import org.apache.hadoop.hbase.client.Mutation;
  *
  * <p>Objects of this class enable persisting failed mutations.
  */
-public class Logger implements AutoCloseable {
+public class FailedMutationLogger implements AutoCloseable {
   private final Serializer serializer;
   private final Appender appender;
+  private final MirroringTracer mirroringTracer;
 
-  Logger() throws IOException {
-    this("/tmp/hbase_mirroring_client_failed_mutations", 1024 * 1024, false);
+  FailedMutationLogger(MirroringTracer mirroringTracer) throws IOException {
+    this(mirroringTracer, "/tmp/hbase_mirroring_client_failed_mutations", 1024 * 1024, false);
   }
 
   /**
@@ -38,6 +42,7 @@ public class Logger implements AutoCloseable {
    * actual writing should be asynchronous, because the failed mutations are buffered and flushed to
    * disk by another thread.
    *
+   * @param mirroringTracer tracer for telemetry
    * @param pathPrefix the prefix of the created log files
    * @param maxBufferSize the maximum amount of log entries kept in memory before flushing to disk
    * @param dropOnOverFlow if this logger is not keeping up with flushing the incoming mutations to
@@ -46,18 +51,26 @@ public class Logger implements AutoCloseable {
    *     thread attempting to write until there some data is flushed to disk
    * @throws IOException on failure to write the log
    */
-  Logger(String pathPrefix, int maxBufferSize, boolean dropOnOverFlow) throws IOException {
-    this(new DefaultAppender(pathPrefix, maxBufferSize, dropOnOverFlow), new DefaultSerializer());
+  FailedMutationLogger(
+      MirroringTracer mirroringTracer, String pathPrefix, int maxBufferSize, boolean dropOnOverFlow)
+      throws IOException {
+    this(
+        mirroringTracer,
+        new DefaultAppender(pathPrefix, maxBufferSize, dropOnOverFlow),
+        new DefaultSerializer());
   }
 
   /**
    * Create a logger with a user-provided implementation of how to serialize log entries and where
    * to store them.
    *
+   * @param mirroringTracer tracer for telemetry
    * @param appender an object responsible for storing log entries
    * @param serializer on object responsible for transforming failed mutations into log entries
    */
-  public Logger(Appender appender, Serializer serializer) {
+  public FailedMutationLogger(
+      MirroringTracer mirroringTracer, Appender appender, Serializer serializer) {
+    this.mirroringTracer = mirroringTracer;
     this.appender = appender;
     this.serializer = serializer;
   }
@@ -74,7 +87,11 @@ public class Logger implements AutoCloseable {
   public void mutationFailed(Mutation mutation, Throwable failureCause)
       throws InterruptedException {
     byte[] serializedEntry = serializer.serialize(mutation, failureCause);
-    appender.append(serializedEntry);
+    try (Scope ignored =
+        mirroringTracer.spanFactory.operationScope(
+            MirroringSpanConstants.HBaseOperation.APPEND_FAILLOG)) {
+      appender.append(serializedEntry);
+    }
   }
 
   @Override

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/faillog/LogBuffer.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/faillog/LogBuffer.java
@@ -84,7 +84,7 @@ public class LogBuffer implements Closeable {
     return false;
   }
 
-  private void waitForAdmissionLocked(byte[] data) throws InterruptedException {
+  private void waitForSpaceAndAdmitLocked(byte[] data) throws InterruptedException {
     while (!admitLocked(data) && !shutdown) {
       notFull.await();
     }
@@ -122,7 +122,7 @@ public class LogBuffer implements Closeable {
           return false;
         }
       } else {
-        waitForAdmissionLocked(data);
+        waitForSpaceAndAdmitLocked(data);
         if (shutdown) {
           throwOnMisuseLocked("LogBuffer closed while waiting for log admission");
         }

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/faillog/README.md
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/faillog/README.md
@@ -29,7 +29,6 @@ mutations.
   * failed mutation
   * operation specific context (i.e. condition of the conditional mutation or
     index in the bulk mutation or read-modify-write proto)
-  * checksum (to ensure integrity in case of a power outage)
 * We log JSON - one message per one line; that way all central logging solutions
   will be able to digest such data in a meaningful way
 * We write our own, custom logging mechanism

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/mirroringmetrics/MirroringSpanConstants.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/mirroringmetrics/MirroringSpanConstants.java
@@ -94,7 +94,8 @@ public class MirroringSpanConstants {
     BUFFERED_MUTATOR_MUTATE_LIST("mutateList"),
     MIRRORING_CONNECTION_CLOSE("MirroringConnection.close"),
     MIRRORING_CONNECTION_ABORT("MirroringConnection.abort"),
-    BUFFERED_MUTATOR_CLOSE("BufferedMutator.close");
+    BUFFERED_MUTATOR_CLOSE("BufferedMutator.close"),
+    APPEND_FAILLOG("appendFaillog");
 
     private final String string;
     private final TagValue tagValue;

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/faillog/FailedMutationLoggerTest.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/test/java/com/google/cloud/bigtable/mirroring/hbase1_x/utils/faillog/FailedMutationLoggerTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.bigtable.mirroring.hbase1_x.utils.faillog;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.google.cloud.bigtable.mirroring.hbase1_x.utils.mirroringmetrics.MirroringTracer;
 import org.apache.hadoop.hbase.client.Mutation;
 import org.apache.hadoop.hbase.client.Put;
 import org.junit.Rule;
@@ -30,18 +31,19 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 @RunWith(JUnit4.class)
-public class LoggerTest {
+public class FailedMutationLoggerTest {
   @Rule public final MockitoRule mockitoRule = MockitoJUnit.rule();
   @Mock Serializer serializer;
   @Mock Appender appender;
 
   @Test
   public void mutationsAreSerializedAndAppended() throws Exception {
-    try (Logger logger = new Logger(appender, serializer)) {
+    try (FailedMutationLogger failedMutationLogger =
+        new FailedMutationLogger(new MirroringTracer(), appender, serializer)) {
       try {
         throw new RuntimeException("OMG!");
       } catch (RuntimeException e) {
-        logger.mutationFailed(new Put(new byte[] {'r'}), e);
+        failedMutationLogger.mutationFailed(new Put(new byte[] {'r'}), e);
       }
     }
     verify(serializer, times(1))


### PR DESCRIPTION
Most significant comments include:
* renaming Logger to `FailedMutationLogger`
* moving parsing `Configuration` to `MirroringOptions`
* adding telemetry for slow appends

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unoperate/java-bigtable-hbase-1/147)
<!-- Reviewable:end -->
