### PR TITLE
fix: ConcurrentBufferedMutator waits for both flushes to finish before closing

### DIFF
--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/mirroring/TestBlocking.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/mirroring/TestBlocking.java
@@ -228,7 +228,7 @@ public class TestBlocking {
     // connection lasted no longer than 3 seconds, but we also need to check that it waited at least
     // `timeoutMillis`. `closeDuration` is strictly greater than timeout because it includes some
     // overhead, but `timeoutMillis` >> expected overhead, thus false-positives are unlikely.
-    assertThat(closeDuration).isGreaterThan(timeoutMillis);
+    assertThat(closeDuration).isAtLeast(timeoutMillis);
     assertThat(c.getPrimaryConnection().isClosed()).isTrue();
     assertThat(c.getSecondaryConnection().isClosed()).isFalse();
 

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/bufferedmutator/ConcurrentMirroringBufferedMutator.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/bufferedmutator/ConcurrentMirroringBufferedMutator.java
@@ -172,6 +172,12 @@ public class ConcurrentMirroringBufferedMutator
   }
 
   @Override
+  protected void flushBufferedMutatorBeforeClosing()
+      throws ExecutionException, InterruptedException {
+    scheduleFlushAll().bothFlushesFinished.get();
+  }
+
+  @Override
   protected FlushFutures scheduleFlushScoped(
       final List<List<? extends Mutation>> dataToFlush, FlushFutures previousFlushFutures) {
     final SettableFuture<Void> bothFlushesFinished = SettableFuture.create();

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/bufferedmutator/MirroringBufferedMutator.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/bufferedmutator/MirroringBufferedMutator.java
@@ -210,6 +210,9 @@ public abstract class MirroringBufferedMutator<BufferEntryType> implements Buffe
     return this.flushSerializer.scheduleFlushAll();
   }
 
+  protected abstract void flushBufferedMutatorBeforeClosing()
+      throws ExecutionException, InterruptedException;
+
   @Override
   public final void close() throws IOException {
     try (Scope scope =
@@ -225,7 +228,7 @@ public abstract class MirroringBufferedMutator<BufferEntryType> implements Buffe
       List<IOException> exceptions = new ArrayList<>();
 
       try {
-        scheduleFlushAll().secondaryFlushFinished.get();
+        flushBufferedMutatorBeforeClosing();
         this.ongoingFlushesCounter.decrementReferenceCount();
         this.ongoingFlushesCounter.getOnLastReferenceClosed().get();
       } catch (InterruptedException | ExecutionException e) {

--- a/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/bufferedmutator/SequentialMirroringBufferedMutator.java
+++ b/bigtable-hbase-mirroring-client-1.x-parent/bigtable-hbase-mirroring-client-1.x/src/main/java/com/google/cloud/bigtable/mirroring/hbase1_x/bufferedmutator/SequentialMirroringBufferedMutator.java
@@ -255,6 +255,12 @@ public class SequentialMirroringBufferedMutator extends MirroringBufferedMutator
   }
 
   @Override
+  protected void flushBufferedMutatorBeforeClosing()
+      throws ExecutionException, InterruptedException {
+    scheduleFlushAll().secondaryFlushFinished.get();
+  }
+
+  @Override
   protected FlushFutures scheduleFlushScoped(
       final List<Entry> dataToFlush, final FlushFutures previousFlushFutures) {
     final SettableFuture<Void> secondaryFlushFinished = SettableFuture.create();

--- a/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-1.x-2.x-integration-tests/pom.xml
+++ b/bigtable-hbase-mirroring-client-2.x-parent/bigtable-hbase-mirroring-client-1.x-2.x-integration-tests/pom.xml
@@ -319,6 +319,13 @@ limitations under the License.
       <scope>test</scope>
       <type>test-jar</type>
     </dependency>
+    <dependency>
+      <groupId>com.google.cloud.bigtable</groupId>
+      <artifactId>bigtable-hbase-mirroring-client-1.x</artifactId>
+      <version>2.0.0-alpha2-SNAPSHOT</version> <!-- {x-version-update:bigtable-client-parent:current} -->
+      <scope>test</scope>
+      <type>test-jar</type>
+    </dependency>
 
     <!-- Needed by MiniHBaseCluster -->
     <dependency>


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unoperate/java-bigtable-hbase-1/161)
<!-- Reviewable:end -->
